### PR TITLE
S3ClientIO ignores the passed in istream pointer

### DIFF
--- a/include/s3_io.h
+++ b/include/s3_io.h
@@ -63,7 +63,7 @@ namespace Minio
       httpDate = "";
       result = "";
       numResult = 0;
-      istrm = NULL;
+      istrm = (i == NULL) ? NULL : i;
       ostrm = (o == NULL)? &response : o;
       bytesToGet = 0; bytesReceived = 0;
       bytesToPut = 0; bytesSent = 0;


### PR DESCRIPTION
`S3ClientIO` ignores the passed in `istream` pointer and hence is not able to execute `PutObject` calls that supply `S3ClientIO` object with custom `istream`