### PR TITLE
bugfix: after using curl_multi_fdset(), selcet() timeout minimum is recommended to be set 100ms, rather than NULL, which may cause current thread always waiting if 'maxfd' equal -1 on some platform.

### DIFF
--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -147,7 +147,7 @@ class Tests {
     }
 
     std::list<minio::s3::DeleteObject>::iterator i = delete_objects.begin();
-    args.func = [&delete_objects = delete_objects,
+    args.func = [& delete_objects = delete_objects,
                  &i = i](minio::s3::DeleteObject& object) -> bool {
       if (i == delete_objects.end()) return false;
       object = *i;
@@ -362,7 +362,7 @@ class Tests {
       args.object = object_name;
       std::string content;
       args.datafunc =
-          [&content = content](minio::http::DataFunctionArgs args) -> bool {
+          [& content = content](minio::http::DataFunctionArgs args) -> bool {
         content += args.datachunk;
         return true;
       };
@@ -571,7 +571,8 @@ class Tests {
 
     try {
       std::string records;
-      auto func = [&records = records](minio::s3::SelectResult result) -> bool {
+      auto func = [& records =
+                       records](minio::s3::SelectResult result) -> bool {
         if (result.err) {
           throw std::runtime_error("SelectResult: " + result.err.String());
           return false;
@@ -602,11 +603,11 @@ class Tests {
     std::cout << "ListenBucketNotification()" << std::endl;
 
     std::list<minio::s3::NotificationRecord> records;
-    std::thread task{[&client_ = client_, &bucket_name_ = bucket_name_,
+    std::thread task{[& client_ = client_, &bucket_name_ = bucket_name_,
                       &records = records]() {
       minio::s3::ListenBucketNotificationArgs args;
       args.bucket = bucket_name_;
-      args.func = [&records = records](
+      args.func = [& records = records](
                       std::list<minio::s3::NotificationRecord> values) -> bool {
         records.insert(records.end(), values.begin(), values.end());
         return false;


### PR DESCRIPTION
see https://github.com/curl/curl/blob/5ccddf64398c1186deb5769dac086d738e150e09/docs/examples/multi-legacy.c

/*On success the value of maxfd is guaranteed to be >= -1. We call
       select(maxfd + 1, ...); specially in case of (maxfd == -1) there are
       no fds ready yet so we call select(0, ...) --or Sleep() on Windows--
       to sleep 100ms, which is the minimum suggested value in the
       curl_multi_fdset() doc.*/