### PR TITLE
Fix bug BucketExists when using aws s3 as storage server

### DIFF
--- a/src/signer.cc
+++ b/src/signer.cc
@@ -34,7 +34,8 @@ std::string minio::signer::GetCanonicalRequestHash(
   //   CanonicalHeaders + '\n\n' +
   //   SignedHeaders + '\n' +
   //   HexEncode(Hash(RequestPayload))
-  std::string canonical_request = method + "\n" + uri + "\n" + query_string +
+  std::string new_uri = uri.empty()?"/":uri;
+  std::string canonical_request = method + "\n" + new_uri + "\n" + query_string +
                                   "\n" + headers + "\n\n" + signed_headers +
                                   "\n" + content_sha256;
   return utils::Sha256Hash(canonical_request);


### PR DESCRIPTION
## What news
- When we check Bucket Exist with aws s3. The uri will be emptied, so Request will be Forbidden