### PR TITLE
Use std::stol() wherever applicable.

### DIFF
--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -1699,7 +1699,7 @@ minio::s3::StatObjectResponse minio::s3::BaseClient::StatObject(
   resp.etag = utils::Trim(response.headers.GetFront("etag"), '"');
 
   std::string value = response.headers.GetFront("content-length");
-  if (!value.empty()) resp.size = std::stoi(value);
+  if (!value.empty()) resp.size = std::stol(value);
 
   value = response.headers.GetFront("last-modified");
   if (!value.empty()) {

--- a/src/response.cc
+++ b/src/response.cc
@@ -228,7 +228,7 @@ minio::s3::ListObjectsResponse minio::s3::ListObjectsResponse::ParseXML(
 
       text = content.node().select_node("Size/text()");
       value = text.node().value();
-      if (!value.empty()) item.size = std::stoi(value);
+      if (!value.empty()) item.size = std::stol(value);
 
       text = content.node().select_node("StorageClass/text()");
       item.storage_class = text.node().value();

--- a/src/select.cc
+++ b/src/select.cc
@@ -183,15 +183,15 @@ bool minio::s3::SelectHandler::process(http::DataFunctionArgs args,
 
     text = root.node().select_node("BytesScanned/text()");
     value = text.node().value();
-    if (!value.empty()) bytes_scanned = std::stoi(value);
+    if (!value.empty()) bytes_scanned = std::stol(value);
 
     text = root.node().select_node("BytesProcessed/text()");
     value = text.node().value();
-    if (!value.empty()) bytes_processed = std::stoi(value);
+    if (!value.empty()) bytes_processed = std::stol(value);
 
     text = root.node().select_node("BytesReturned/text()");
     value = text.node().value();
-    if (!value.empty()) bytes_returned = std::stoi(value);
+    if (!value.empty()) bytes_returned = std::stol(value);
 
     cont = result_func_(
         SelectResult(bytes_scanned, bytes_processed, bytes_returned));


### PR DESCRIPTION
Fixes #77