### PR TITLE
Add curlpp::Options::SslVerifyHost(0L) for ignore_cert_check flag

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -190,11 +190,13 @@ minio::http::Response minio::http::Request::execute() {
   if (debug) request.setOpt(new curlpp::Options::Verbose(true));
   if (ignore_cert_check) {
     request.setOpt(new curlpp::Options::SslVerifyPeer(false));
+    request.setOpt(new curlpp::Options::SslVerifyHost(0L));
   }
 
   if (url.https) {
     if (!ssl_cert_file.empty()) {
       request.setOpt(new curlpp::Options::SslVerifyPeer(true));
+      request.setOpt(new curlpp::Options::SslVerifyHost(2L));
       request.setOpt(new curlpp::Options::CaInfo(ssl_cert_file));
     }
     if (!key_file.empty()) {

--- a/src/http.cc
+++ b/src/http.cc
@@ -196,7 +196,6 @@ minio::http::Response minio::http::Request::execute() {
   if (url.https) {
     if (!ssl_cert_file.empty()) {
       request.setOpt(new curlpp::Options::SslVerifyPeer(true));
-      request.setOpt(new curlpp::Options::SslVerifyHost(2L));
       request.setOpt(new curlpp::Options::CaInfo(ssl_cert_file));
     }
     if (!key_file.empty()) {


### PR DESCRIPTION
In addition to `CURLOPT_SSL_VERIFYPEER`, libcurl also has `CURLOPT_SSL_VERIFYHOST` which when set to `2L` strictly checks the hostname provided against hostnames in the site's certificate. When running in insecure mode, this value should be set to `0L` to allow a connection to a host not listed in the certificate (which is the case in some test MinIO deployment configurations).

I have a MinIO tenant deployed via the MinIO operator on a RKE2-based k8s deployment that I use for development and testing purposes. This configuration uses the default CA generated for the cluster, which is not a trusted CA. The executable generated by the build for `src/tests/tests.cc` fails on the first request because curlpp (libcurl) cannot verify the hostname of MinIO service (it is just an IP address).

This fix explicitly sets the value of `CURLOPT_SSL_VERIFYHOST` in both cases (secure/insecure). In the secure case, it is simply set to what is already the default value. Feel free to remove that line if you do not prefer explicit configuration.

References:
[https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html](https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html)
[https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html](https://curl.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html)