### PR TITLE
Add MS Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       shell: bash
       if: startsWith(matrix.config.os, 'windows')
       run: |
-        choco install -y cmake wget
+        choco install -y --no-progress cmake wget
         wget --quiet https://dl.min.io/server/minio/release/windows-amd64/minio.exe
         chmod +x minio.exe
         cmake --version
@@ -146,7 +146,7 @@ jobs:
       shell: bash
       if: startsWith(matrix.config.os, 'windows')
       run: |
-        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./build/tests/tests.exe
+        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./build/tests/Release/tests.exe
 
     - name: Run CMake test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       run: |
         mkdir -p ~/.minio/certs
         cp ./tests/public.crt ./tests/private.key ~/.minio/certs/
+        certutil -addstore -f "ROOT" ./tests/public.crt
         MINIO_CI_CD=true ./minio.exe server test-xl/{1...4}/ &
         sleep 10
 
@@ -145,7 +146,7 @@ jobs:
       shell: bash
       if: startsWith(matrix.config.os, 'windows')
       run: |
-        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ./build/tests/tests.exe
+        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./build/tests/tests.exe
 
     - name: Run CMake test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
       if: startsWith(matrix.config.os, 'windows')
       shell: bash
       run: |
+        mkdir -p ~/.minio/certs
+        cp ./tests/public.crt ./tests/private.key ~/.minio/certs/
         MINIO_CI_CD=true ./minio.exe server test-xl/{1...4}/ &
         sleep 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       if: startsWith(matrix.config.os, 'windows')
       shell: bash
       run: |
-        MINIO_CI_CD=true ./minio.exe server /tmp/test-xl/{1...4}/ &
+        MINIO_CI_CD=true ./minio.exe server test-xl/{1...4}/ &
         sleep 10
 
     - name: Run tests if Ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
             cc: "clang",
             cxx: "clang++"
           }
+        - {
+            name: "Windows Latest MSVC",
+            os: windows-latest,
+            build_type: "Release",
+            cc: "cl",
+            cxx: "cl"
+          }
 
     steps:
     - uses: actions/checkout@v2
@@ -67,6 +74,15 @@ jobs:
         minio --version
         clang-format --version
 
+    - name: Install dependencies if Windows
+      shell: bash
+      if: startsWith(matrix.config.os, 'windows')
+      run: |
+        choco install -y cmake wget
+        wget --quiet https://dl.min.io/server/minio/release/windows-amd64/minio.exe
+        chmod +x minio.exe
+        cmake --version
+
     - name: Install vcpkg
       shell: bash
       run: |
@@ -78,7 +94,8 @@ jobs:
         ./vcpkg-master/vcpkg integrate install
         ./vcpkg-master/vcpkg install
 
-    - name: C++ Style check
+    - name: C++ Style check if not Windows
+      if: ${{ !startsWith(matrix.config.os, 'windows') }}
       shell: bash
       run: |
         ./check-style.sh
@@ -105,6 +122,13 @@ jobs:
         MINIO_CI_CD=true minio server test-xl/{1...4}/ &
         sleep 10
 
+    - name: Start MinIO server if Windows
+      if: startsWith(matrix.config.os, 'windows')
+      shell: bash
+      run: |
+        MINIO_CI_CD=true ./minio.exe server /tmp/test-xl/{1...4}/ &
+        sleep 10
+
     - name: Run tests if Ubuntu
       if: startsWith(matrix.config.name, 'Ubuntu_Latest_GCC')
       run: |
@@ -114,6 +138,12 @@ jobs:
       if: startsWith(matrix.config.name, 'macos')
       run: |
         SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ./build/tests/tests
+
+    - name: Run tests if Windows
+      shell: bash
+      if: startsWith(matrix.config.os, 'windows')
+      run: |
+        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ./build/tests/tests.exe
 
     - name: Run CMake test
       working-directory: ${{github.workspace}}/build

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ docs/*svg
 docs/*map
 docs/*md5
 include/config.h
+.idea/
+cmake-build*
+vcpkg-master.zip
+vcpkg-master/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(SET CMP0091 NEW)
 
 project(miniocpp)
-
-cmake_minimum_required(VERSION 3.10)
 
 include(GNUInstallDirs)
 
@@ -79,6 +79,12 @@ IF(OPENSSL_FOUND)
 ELSE(OPENSSL_FOUND)
   MESSAGE(FATAL_ERROR "Could not find the OpenSSL library and development files.")
 ENDIF(OPENSSL_FOUND)
+
+if(WIN32)
+    list(APPEND requiredlibs wsock32)
+    list(APPEND requiredlibs ws2_32)
+    list(APPEND requiredlibs ZLIB::ZLIB)
+endif()
 
 message(STATUS "Found required libs: ${requiredlibs}")
 

--- a/include/http.h
+++ b/include/http.h
@@ -16,7 +16,11 @@
 #ifndef _MINIO_HTTP_H
 #define _MINIO_HTTP_H
 
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
+#endif
 
 #include <curlpp/Easy.hpp>
 #include <curlpp/Multi.hpp>

--- a/include/providers.h
+++ b/include/providers.h
@@ -17,9 +17,14 @@
 #define _MINIO_CREDS_PROVIDERS_H
 
 #include <INIReader.h>
+#ifdef _WIN32
+#include <ws2def.h>
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/socket.h>
+#endif
 #include <sys/types.h>
 
 #include <fstream>

--- a/include/utils.h
+++ b/include/utils.h
@@ -45,7 +45,7 @@ namespace minio {
 namespace utils {
 inline constexpr unsigned int kMaxMultipartCount = 10000;  // 10000 parts
 inline constexpr unsigned long long kMaxObjectSize = 5497558138880ULL;  // 5TiB
-inline constexpr unsigned long long kMaxPartSize = 5368709120UL;  // 5GiB
+inline constexpr unsigned long long kMaxPartSize = 5368709120UL;        // 5GiB
 inline constexpr unsigned int kMinPartSize = 5 * 1024 * 1024;           // 5MiB
 
 bool GetEnv(std::string& var, const char* name);
@@ -149,7 +149,8 @@ class Time {
   static Time Now() {
     Time t;
     auto now = std::chrono::high_resolution_clock::now();
-    auto usec = std::chrono::system_clock::now().time_since_epoch() / std::chrono::microseconds(1);
+    auto usec = std::chrono::system_clock::now().time_since_epoch() /
+                std::chrono::microseconds(1);
     t.tv_.tv_sec = static_cast<long>(usec / 1000000);
     t.tv_.tv_usec = static_cast<long>(usec % 1000000);
     return t;

--- a/include/utils.h
+++ b/include/utils.h
@@ -148,7 +148,6 @@ class Time {
 
   static Time Now() {
     Time t;
-    auto now = std::chrono::high_resolution_clock::now();
     auto usec = std::chrono::system_clock::now().time_since_epoch() /
                 std::chrono::microseconds(1);
     t.tv_.tv_sec = static_cast<long>(usec / 1000000);

--- a/src/client.cc
+++ b/src/client.cc
@@ -637,7 +637,7 @@ minio::s3::DownloadObjectResponse minio::s3::Client::DownloadObject(
 
   std::string temp_filename =
       args.filename + "." + curlpp::escape(etag) + ".part.minio";
-  std::ofstream fout(temp_filename, fout.trunc | fout.out);
+  std::ofstream fout(temp_filename, std::ios::trunc | std::ios::out);
   if (!fout.is_open()) {
     return error::Error("unable to open file " + temp_filename);
   }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -52,8 +52,8 @@ bool minio::utils::GetEnv(std::string& var, const char* name) {
 std::string minio::utils::GetHomeDir() {
   std::string home;
 #ifdef _WIN32
-  if (GetEnv(home, "USERPROFILE")) return home;
-  return "";
+  GetEnv(home, "USERPROFILE");
+  return home;
 #else
   if (GetEnv(home, "HOME")) return home;
   return getpwuid(getuid())->pw_dir;

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -28,6 +28,21 @@ const std::regex IPV4_REGEX(
     "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}"
     "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$");
 
+#ifdef _WIN32
+// strptime is defined here because it's not available on Windows.
+static char* strptime(const char* s,
+                          const char* f,
+                          struct tm* tm) {
+    std::istringstream input(s);
+    input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
+    input >> std::get_time(tm, f);
+    if (input.fail()) {
+        return nullptr;
+    }
+    return (char*)(s + input.tellg());
+}
+#endif
+
 bool minio::utils::GetEnv(std::string& var, const char* name) {
   if (const char* value = std::getenv(name)) {
     var = value;
@@ -39,7 +54,12 @@ bool minio::utils::GetEnv(std::string& var, const char* name) {
 std::string minio::utils::GetHomeDir() {
   std::string home;
   if (GetEnv(home, "HOME")) return home;
+  if (GetEnv(home, "USERPROFILE")) return home;
+#ifdef _WIN32
+  return "";
+#else
   return getpwuid(getuid())->pw_dir;
+#endif
 }
 
 std::string minio::utils::Printable(std::string s) {
@@ -258,7 +278,8 @@ std::string minio::utils::FormatTime(const std::tm* time, const char* format) {
 
 std::tm* minio::utils::Time::ToUTC() {
   std::tm* t = new std::tm;
-  *t = utc_ ? *std::localtime(&tv_.tv_sec) : *std::gmtime(&tv_.tv_sec);
+  const time_t secs =  tv_.tv_sec;
+  *t = utc_ ? *std::localtime(&secs) : *std::gmtime(&secs);
   return t;
 }
 
@@ -336,7 +357,7 @@ minio::utils::Time minio::utils::Time::FromISO8601UTC(const char* value) {
   char* rv = strptime(value, "%Y-%m-%dT%H:%M:%S", &t);
   unsigned long ul = 0;
   sscanf(rv, ".%lu", &ul);
-  suseconds_t tv_usec = (suseconds_t)ul;
+  long tv_usec = (long)ul;
   std::time_t time = std::mktime(&t);
   return Time(time, tv_usec, true);
 }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -51,11 +51,11 @@ bool minio::utils::GetEnv(std::string& var, const char* name) {
 
 std::string minio::utils::GetHomeDir() {
   std::string home;
-  if (GetEnv(home, "HOME")) return home;
-  if (GetEnv(home, "USERPROFILE")) return home;
 #ifdef _WIN32
+  if (GetEnv(home, "USERPROFILE")) return home;
   return "";
 #else
+  if (GetEnv(home, "HOME")) return home;
   return getpwuid(getuid())->pw_dir;
 #endif
 }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -30,16 +30,14 @@ const std::regex IPV4_REGEX(
 
 #ifdef _WIN32
 // strptime is defined here because it's not available on Windows.
-static char* strptime(const char* s,
-                          const char* f,
-                          struct tm* tm) {
-    std::istringstream input(s);
-    input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
-    input >> std::get_time(tm, f);
-    if (input.fail()) {
-        return nullptr;
-    }
-    return (char*)(s + input.tellg());
+static char* strptime(const char* s, const char* f, struct tm* tm) {
+  std::istringstream input(s);
+  input.imbue(std::locale(setlocale(LC_ALL, nullptr)));
+  input >> std::get_time(tm, f);
+  if (input.fail()) {
+    return nullptr;
+  }
+  return (char*)(s + input.tellg());
 }
 #endif
 
@@ -278,7 +276,7 @@ std::string minio::utils::FormatTime(const std::tm* time, const char* format) {
 
 std::tm* minio::utils::Time::ToUTC() {
   std::tm* t = new std::tm;
-  const time_t secs =  tv_.tv_sec;
+  const time_t secs = tv_.tv_sec;
   *t = utc_ ? *std::localtime(&secs) : *std::gmtime(&secs);
   return t;
 }

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -621,7 +621,8 @@ class Tests {
       }
     }};
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10)); // sleep for 10ms.
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(10));  // sleep for 10ms.
 
     std::string object_name = RandObjectName();
     try {

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -12,9 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include <unistd.h>
-
+#include <chrono>
 #include <random>
 #include <thread>
 
@@ -39,7 +37,7 @@ class RandomBuf : public std::streambuf {
   int_type underflow() override {
     if (size_ == 0) return EOF;
 
-    size_t size = std::min(size_, buf_.size());
+    size_t size = std::min<size_t>(size_, buf_.size());
     setg(&buf_[0], &buf_[0], &buf_[size]);
     for (size_t i = 0; i < size; ++i) buf_[i] = charset[pick(rg)];
     size_ -= size;
@@ -623,7 +621,7 @@ class Tests {
       }
     }};
 
-    usleep(10 * 1000);  // sleep for 10ms.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10)); // sleep for 10ms.
 
     std::string object_name = RandObjectName();
     try {

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -621,8 +621,7 @@ class Tests {
       }
     }};
 
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(10));  // sleep for 10ms.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     std::string object_name = RandObjectName();
     try {


### PR DESCRIPTION
This should work with either MSVC or clang-cl. I've tested that the build and some example programs work on Ubuntu 22.04 and Windows 11 (both x64), but I can't run all the tests without a sever endpoint set and I don't have a Mac to test against, so there might still be some problems to fix after CI runs.

If the team is okay with moving forward with Windows support, I'd also be happy to add CI workflow steps for the build and tests and update the vcpkg port!