### PR TITLE
Fixed the out of bound read; fixed exception safety

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -683,16 +683,10 @@ minio::s3::PutObjectResponse minio::s3::Client::PutObject(PutObjectArgs args) {
         "SSE operation must be performed over a secure connection");
   }
 
-  char* buf = NULL;
-  if (args.part_count > 0) {
-    buf = new char[args.part_size];
-  } else {
-    buf = new char[args.part_size + 1];
-  }
-
   std::string upload_id;
-  PutObjectResponse resp = PutObject(args, upload_id, buf);
-  delete[] buf;
+  auto buf = std::make_unique<char[]>((args.part_count > 0) ? args.part_size : args.part_size + 1);
+  PutObjectResponse resp = PutObject(args, upload_id, buf.get());
+  buf.reset();
 
   if (!resp && !upload_id.empty()) {
     AbortMultipartUploadArgs amu_args;

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -38,7 +38,8 @@ class RandomBuf : public std::streambuf {
     if (size_ == 0) return EOF;
 
     size_t size = std::min<size_t>(size_, buf_.size());
-    setg(&buf_[0], &buf_[0], &buf_[size]);
+    auto* const data = buf_.data();
+    setg(data, data, data + size);
     for (size_t i = 0; i < size; ++i) buf_[i] = charset[pick(rg)];
     size_ -= size;
     return 0;


### PR DESCRIPTION
1. Fixed the out-of-bound read in tests, as detected on Windows
2. Fixed exception safety: the buffer would leak in the case of exception.