### PR TITLE
Converting constructor removal; distinct types; thread-safe time access

### DIFF
--- a/include/args.h
+++ b/include/args.h
@@ -231,6 +231,12 @@ struct ListObjectsArgs : public BucketArgs {
 
   ListObjectsArgs() = default;
   ~ListObjectsArgs() = default;
+
+  ListObjectsArgs(const ListObjectsArgs &) = default;
+  ListObjectsArgs &operator=(const ListObjectsArgs &) = default;
+
+  ListObjectsArgs(ListObjectsArgs &&) = default;
+  ListObjectsArgs &operator=(ListObjectsArgs &&) = default;
 };  // struct ListObjectsArgs
 
 struct ListObjectsCommonArgs : public BucketArgs {
@@ -241,14 +247,29 @@ struct ListObjectsCommonArgs : public BucketArgs {
 
   ListObjectsCommonArgs() = default;
   ~ListObjectsCommonArgs() = default;
+
+  ListObjectsCommonArgs(const ListObjectsCommonArgs &) = default;
+  ListObjectsCommonArgs &operator=(const ListObjectsCommonArgs &) = default;
+
+  ListObjectsCommonArgs(ListObjectsCommonArgs &&) = default;
+  ListObjectsCommonArgs &operator=(ListObjectsCommonArgs &&) = default;
 };  // struct ListObjectsCommonArgs
 
 struct ListObjectsV1Args : public ListObjectsCommonArgs {
   std::string marker;
 
   ListObjectsV1Args();
-  ListObjectsV1Args(ListObjectsArgs args);
+
+  explicit ListObjectsV1Args(ListObjectsArgs args);
+  ListObjectsV1Args &operator=(ListObjectsArgs args);
+
   ~ListObjectsV1Args() = default;
+
+  ListObjectsV1Args(const ListObjectsV1Args &) = default;
+  ListObjectsV1Args &operator=(const ListObjectsV1Args &) = default;
+
+  ListObjectsV1Args(ListObjectsV1Args &&) = default;
+  ListObjectsV1Args &operator=(ListObjectsV1Args &&) = default;
 };  // struct ListObjectsV1Args
 
 struct ListObjectsV2Args : public ListObjectsCommonArgs {
@@ -258,8 +279,17 @@ struct ListObjectsV2Args : public ListObjectsCommonArgs {
   bool include_user_metadata = false;
 
   ListObjectsV2Args();
-  ListObjectsV2Args(ListObjectsArgs args);
+
+  explicit ListObjectsV2Args(ListObjectsArgs args);
+  ListObjectsV2Args &operator=(ListObjectsArgs args);
+
   ~ListObjectsV2Args() = default;
+
+  ListObjectsV2Args(const ListObjectsV2Args &) = default;
+  ListObjectsV2Args &operator=(const ListObjectsV2Args &) = default;
+
+  ListObjectsV2Args(ListObjectsV2Args &&) = default;
+  ListObjectsV2Args &operator=(ListObjectsV2Args &&) = default;
 };  // struct ListObjectsV2Args
 
 struct ListObjectVersionsArgs : public ListObjectsCommonArgs {
@@ -267,8 +297,17 @@ struct ListObjectVersionsArgs : public ListObjectsCommonArgs {
   std::string version_id_marker;
 
   ListObjectVersionsArgs();
-  ListObjectVersionsArgs(ListObjectsArgs args);
+
+  explicit ListObjectVersionsArgs(ListObjectsArgs args);
+  ListObjectVersionsArgs &operator=(ListObjectsArgs args);
+
   ~ListObjectVersionsArgs() = default;
+
+  ListObjectVersionsArgs(const ListObjectVersionsArgs &) = default;
+  ListObjectVersionsArgs &operator=(const ListObjectVersionsArgs &) = default;
+
+  ListObjectVersionsArgs(ListObjectVersionsArgs &&) = default;
+  ListObjectVersionsArgs &operator=(ListObjectVersionsArgs &&) = default;
 };  // struct ListObjectVersionsArgs
 
 struct PutObjectArgs : public PutObjectBaseArgs {
@@ -393,7 +432,7 @@ using GetBucketNotificationArgs = BucketArgs;
 struct SetBucketNotificationArgs : public BucketArgs {
   NotificationConfig &config;
 
-  SetBucketNotificationArgs(NotificationConfig &configvalue)
+  explicit SetBucketNotificationArgs(NotificationConfig &configvalue)
       : config(configvalue) {}
 
   ~SetBucketNotificationArgs() = default;
@@ -406,7 +445,8 @@ using GetBucketEncryptionArgs = BucketArgs;
 struct SetBucketEncryptionArgs : public BucketArgs {
   SseConfig &config;
 
-  SetBucketEncryptionArgs(SseConfig &sseconfig) : config(sseconfig) {}
+  explicit SetBucketEncryptionArgs(SseConfig &sseconfig) : config(sseconfig) {}
+
   ~SetBucketEncryptionArgs() = default;
 
   error::Error Validate() const;
@@ -431,7 +471,8 @@ using GetBucketReplicationArgs = BucketArgs;
 struct SetBucketReplicationArgs : public BucketArgs {
   ReplicationConfig &config;
 
-  SetBucketReplicationArgs(ReplicationConfig &value) : config(value) {}
+  explicit SetBucketReplicationArgs(ReplicationConfig &value) : config(value) {}
+
   ~SetBucketReplicationArgs() = default;
 };  // struct SetBucketReplication
 
@@ -442,7 +483,8 @@ using GetBucketLifecycleArgs = BucketArgs;
 struct SetBucketLifecycleArgs : public BucketArgs {
   LifecycleConfig &config;
 
-  SetBucketLifecycleArgs(LifecycleConfig &value) : config(value) {}
+  explicit SetBucketLifecycleArgs(LifecycleConfig &value) : config(value) {}
+
   ~SetBucketLifecycleArgs() = default;
 };  // struct SetBucketLifecycle
 

--- a/include/baseclient.h
+++ b/include/baseclient.h
@@ -51,6 +51,7 @@ class BaseClient {
  public:
   explicit BaseClient(BaseUrl base_url,
                       creds::Provider* const provider = nullptr);
+
   virtual ~BaseClient() = default;
 
   void Debug(bool flag) { debug_ = flag; }

--- a/include/client.h
+++ b/include/client.h
@@ -41,13 +41,14 @@ class ListObjectsResult {
   void Populate();
 
  public:
-  ListObjectsResult(error::Error err);
+  explicit ListObjectsResult(error::Error err);
   ListObjectsResult(Client* const client, const ListObjectsArgs& args);
   ListObjectsResult(Client* const client, ListObjectsArgs&& args);
   ~ListObjectsResult() = default;
 
   Item& operator*() const { return *itr_; }
   explicit operator bool() const { return itr_ != resp_.contents.end(); }
+
   ListObjectsResult& operator++() {
     itr_++;
     if (!failed_ && itr_ == resp_.contents.end() && resp_.is_truncated) {
@@ -55,6 +56,7 @@ class ListObjectsResult {
     }
     return *this;
   }
+
   ListObjectsResult operator++(int) {
     ListObjectsResult curr = *this;
     ++(*this);
@@ -73,7 +75,7 @@ class RemoveObjectsResult {
   void Populate();
 
  public:
-  RemoveObjectsResult(error::Error err);
+  explicit RemoveObjectsResult(error::Error err);
   RemoveObjectsResult(Client* const client, const RemoveObjectsArgs& args);
   RemoveObjectsResult(Client* const client, RemoveObjectsArgs&& args);
   ~RemoveObjectsResult() = default;
@@ -108,7 +110,7 @@ class Client : public BaseClient {
                               char* buf);
 
  public:
-  Client(BaseUrl& base_url, creds::Provider* const provider = nullptr);
+  explicit Client(BaseUrl& base_url, creds::Provider* const provider = nullptr);
   ~Client() = default;
 
   ComposeObjectResponse ComposeObject(ComposeObjectArgs args);

--- a/include/error.h
+++ b/include/error.h
@@ -33,14 +33,8 @@ class Error {
   Error(const Error&) = default;
   Error& operator=(const Error&) = default;
 
-  Error(Error&& v) noexcept : msg_(std::move(v.msg_)) {}
-
-  Error& operator=(Error&& v) noexcept {
-    if (this != &v) {
-      msg_ = std::move(v.msg_);
-    }
-    return *this;
-  }
+  Error(Error&& v) = default;
+  Error& operator=(Error&& v) = default;
 
   ~Error() = default;
 
@@ -53,6 +47,11 @@ class Error {
 };  // class Error
 
 const static Error SUCCESS;
+
+template <typename T_RESULT, typename... TA>
+inline T_RESULT make(TA&&... args) {
+  return T_RESULT{Error(std::forward<TA>(args)...)};
+}
 }  // namespace error
 }  // namespace minio
 

--- a/include/providers.h
+++ b/include/providers.h
@@ -70,7 +70,7 @@ class ChainedProvider : public Provider {
   Provider* provider_ = nullptr;
 
  public:
-  ChainedProvider(std::list<Provider*> providers)
+  explicit ChainedProvider(std::list<Provider*> providers)
       : providers_(std::move(providers)) {}
 
   virtual ~ChainedProvider();
@@ -108,7 +108,8 @@ class EnvMinioProvider : public Provider {
 
 class AwsConfigProvider : public Provider {
  public:
-  AwsConfigProvider(std::string filename = {}, std::string profile = {});
+  explicit AwsConfigProvider(std::string filename = {},
+                             std::string profile = {});
   virtual ~AwsConfigProvider();
 
   virtual Credentials Fetch() override;
@@ -116,7 +117,8 @@ class AwsConfigProvider : public Provider {
 
 class MinioClientConfigProvider : public Provider {
  public:
-  MinioClientConfigProvider(std::string filename = {}, std::string alias = {});
+  explicit MinioClientConfigProvider(std::string filename = {},
+                                     std::string alias = {});
   virtual ~MinioClientConfigProvider();
 
   virtual Credentials Fetch() override;
@@ -204,7 +206,7 @@ class IamAwsProvider : public Provider {
   std::string full_uri_;
 
  public:
-  IamAwsProvider(http::Url custom_endpoint = http::Url());
+  explicit IamAwsProvider(http::Url custom_endpoint = http::Url());
   virtual ~IamAwsProvider();
 
   virtual Credentials Fetch() override;

--- a/include/request.h
+++ b/include/request.h
@@ -71,7 +71,8 @@ struct BaseUrl {
   bool virtual_style = false;
 
   BaseUrl() = default;
-  BaseUrl(std::string host, bool https = true, std::string region = {});
+  explicit BaseUrl(std::string host, bool https = true,
+                   std::string region = {});
   ~BaseUrl() = default;
 
   error::Error BuildUrl(http::Url& url, http::Method method,
@@ -83,7 +84,9 @@ struct BaseUrl {
   explicit operator bool() const { return !err_ && !host.empty(); }
 
   error::Error Error() const {
-    if (host.empty() && !err_) return error::Error("empty host");
+    if (host.empty() && !err_) {
+      return error::Error("empty host");
+    }
     return err_;
   }
 

--- a/include/response.h
+++ b/include/response.h
@@ -65,38 +65,40 @@ struct Response {
   error::Error err_;
 };  // struct Response
 
-
-#define MINIO_S3_DERIVE_FROM_RESPONSE(DerivedName)                                                  \
-  struct DerivedName : public Response {                                                            \
-    DerivedName() = default;                                                                        \
-    ~DerivedName() = default;                                                                       \
-                                                                                                    \
-    DerivedName(const DerivedName&) = default;                                                      \
-    DerivedName& operator =(const DerivedName&) = default;                                          \
-                                                                                                    \
-    DerivedName(DerivedName&&) = default;                                                           \
-    DerivedName& operator =(DerivedName&&) = default;                                               \
-                                                                                                    \
-    explicit DerivedName(error::Error err) : Response(std::move(err)) {}                            \
-    explicit DerivedName(const Response& resp) : Response(resp) {}                                  \
+#define MINIO_S3_DERIVE_FROM_RESPONSE(DerivedName)                       \
+  struct DerivedName : public Response {                                 \
+    DerivedName() = default;                                             \
+    ~DerivedName() = default;                                            \
+                                                                         \
+    DerivedName(const DerivedName&) = default;                           \
+    DerivedName& operator=(const DerivedName&) = default;                \
+                                                                         \
+    DerivedName(DerivedName&&) = default;                                \
+    DerivedName& operator=(DerivedName&&) = default;                     \
+                                                                         \
+    explicit DerivedName(error::Error err) : Response(std::move(err)) {} \
+    explicit DerivedName(const Response& resp) : Response(resp) {}       \
   };
 
-#define MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(DerivedName)                                       \
-  struct DerivedName : public PutObjectResponse {                                                   \
-    DerivedName() = default;                                                                        \
-    ~DerivedName() = default;                                                                       \
-                                                                                                    \
-    DerivedName(const DerivedName&) = default;                                                      \
-    DerivedName& operator =(const DerivedName&) = default;                                          \
-                                                                                                    \
-    DerivedName(DerivedName&&) = default;                                                           \
-    DerivedName& operator =(DerivedName&&) = default;                                               \
-                                                                                                    \
-    explicit DerivedName(error::Error err) : PutObjectResponse(std::move(err)) {}                   \
-    explicit DerivedName(const PutObjectResponse& resp) : PutObjectResponse(resp) {}                \
-    explicit DerivedName(const Response& resp) : PutObjectResponse(resp) {}                         \
-                                                                                                    \
-    explicit DerivedName(const CompleteMultipartUploadResponse& resp) : PutObjectResponse(resp) {}  \
+#define MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(DerivedName)               \
+  struct DerivedName : public PutObjectResponse {                           \
+    DerivedName() = default;                                                \
+    ~DerivedName() = default;                                               \
+                                                                            \
+    DerivedName(const DerivedName&) = default;                              \
+    DerivedName& operator=(const DerivedName&) = default;                   \
+                                                                            \
+    DerivedName(DerivedName&&) = default;                                   \
+    DerivedName& operator=(DerivedName&&) = default;                        \
+                                                                            \
+    explicit DerivedName(error::Error err)                                  \
+        : PutObjectResponse(std::move(err)) {}                              \
+    explicit DerivedName(const PutObjectResponse& resp)                     \
+        : PutObjectResponse(resp) {}                                        \
+    explicit DerivedName(const Response& resp) : PutObjectResponse(resp) {} \
+                                                                            \
+    explicit DerivedName(const CompleteMultipartUploadResponse& resp)       \
+        : PutObjectResponse(resp) {}                                        \
   };
 
 struct GetRegionResponse : public Response {
@@ -106,8 +108,7 @@ struct GetRegionResponse : public Response {
 
   explicit GetRegionResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit GetRegionResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetRegionResponse(const Response& resp) : Response(resp) {}
 
   ~GetRegionResponse() = default;
 };  // struct GetRegionResponse
@@ -122,8 +123,7 @@ struct ListBucketsResponse : public Response {
 
   explicit ListBucketsResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit ListBucketsResponse(const Response& resp)
-    : Response(resp) {}
+  explicit ListBucketsResponse(const Response& resp) : Response(resp) {}
 
   ~ListBucketsResponse() = default;
 
@@ -137,8 +137,7 @@ struct BucketExistsResponse : public Response {
 
   explicit BucketExistsResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit BucketExistsResponse(const Response& resp)
-    : Response(resp) {}
+  explicit BucketExistsResponse(const Response& resp) : Response(resp) {}
 
   ~BucketExistsResponse() = default;
 };  // struct BucketExistsResponse
@@ -157,7 +156,7 @@ struct CompleteMultipartUploadResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit CompleteMultipartUploadResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~CompleteMultipartUploadResponse() = default;
 
@@ -175,7 +174,7 @@ struct CreateMultipartUploadResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit CreateMultipartUploadResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~CreateMultipartUploadResponse() = default;
 };  // struct CreateMultipartUploadResponse
@@ -188,8 +187,7 @@ struct PutObjectResponse : public Response {
 
   explicit PutObjectResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit PutObjectResponse(const Response& resp)
-    : Response(resp) {}
+  explicit PutObjectResponse(const Response& resp) : Response(resp) {}
 
   explicit PutObjectResponse(const CompleteMultipartUploadResponse& resp)
       : Response(resp), etag(resp.etag), version_id(resp.version_id) {}
@@ -215,8 +213,7 @@ struct StatObjectResponse : public Response {
 
   explicit StatObjectResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit StatObjectResponse(const Response& resp)
-    : Response(resp) {}
+  explicit StatObjectResponse(const Response& resp) : Response(resp) {}
 
   ~StatObjectResponse() = default;
 };  // struct StatObjectResponse
@@ -244,8 +241,7 @@ struct Item : public Response {
 
   explicit Item(error::Error err) : Response(std::move(err)) {}
 
-  explicit Item(const Response& resp)
-    : Response(resp) {}
+  explicit Item(const Response& resp) : Response(resp) {}
 
   ~Item() = default;
 };  // struct Item
@@ -280,8 +276,7 @@ struct ListObjectsResponse : public Response {
 
   explicit ListObjectsResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit ListObjectsResponse(const Response& resp)
-    : Response(resp) {}
+  explicit ListObjectsResponse(const Response& resp) : Response(resp) {}
 
   ~ListObjectsResponse() = default;
 
@@ -309,8 +304,7 @@ struct DeleteError : public Response {
 
   explicit DeleteError(error::Error err) : Response(std::move(err)) {}
 
-  explicit DeleteError(const Response& resp)
-    : Response(resp) {}
+  explicit DeleteError(const Response& resp) : Response(resp) {}
 
   ~DeleteError() = default;
 };  // struct DeleteError
@@ -323,8 +317,7 @@ struct RemoveObjectsResponse : public Response {
 
   explicit RemoveObjectsResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit RemoveObjectsResponse(const Response& resp)
-    : Response(resp) {}
+  explicit RemoveObjectsResponse(const Response& resp) : Response(resp) {}
 
   ~RemoveObjectsResponse() = default;
 
@@ -344,8 +337,7 @@ struct GetBucketPolicyResponse : public Response {
   explicit GetBucketPolicyResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  explicit GetBucketPolicyResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetBucketPolicyResponse(const Response& resp) : Response(resp) {}
 
   ~GetBucketPolicyResponse() = default;
 };  // struct GetBucketPolicyResponse
@@ -363,7 +355,7 @@ struct GetBucketNotificationResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit GetBucketNotificationResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~GetBucketNotificationResponse() = default;
 
@@ -382,8 +374,7 @@ struct GetBucketEncryptionResponse : public Response {
   explicit GetBucketEncryptionResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  explicit GetBucketEncryptionResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetBucketEncryptionResponse(const Response& resp) : Response(resp) {}
 
   ~GetBucketEncryptionResponse() = default;
 
@@ -401,8 +392,7 @@ struct GetBucketVersioningResponse : public Response {
   explicit GetBucketVersioningResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  explicit GetBucketVersioningResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetBucketVersioningResponse(const Response& resp) : Response(resp) {}
 
   ~GetBucketVersioningResponse() = default;
 
@@ -432,7 +422,7 @@ struct GetBucketReplicationResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit GetBucketReplicationResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~GetBucketReplicationResponse() = default;
 
@@ -451,8 +441,7 @@ struct GetBucketLifecycleResponse : public Response {
   explicit GetBucketLifecycleResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  explicit GetBucketLifecycleResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetBucketLifecycleResponse(const Response& resp) : Response(resp) {}
 
   static GetBucketLifecycleResponse ParseXML(std::string_view data);
 };  // struct GetBucketLifecycleResponse
@@ -468,8 +457,7 @@ struct GetBucketTagsResponse : public Response {
 
   explicit GetBucketTagsResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit GetBucketTagsResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetBucketTagsResponse(const Response& resp) : Response(resp) {}
 
   ~GetBucketTagsResponse() = default;
 
@@ -488,8 +476,7 @@ struct GetObjectLockConfigResponse : public Response {
   explicit GetObjectLockConfigResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  explicit GetObjectLockConfigResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetObjectLockConfigResponse(const Response& resp) : Response(resp) {}
 
   ~GetObjectLockConfigResponse() = default;
 };  // struct GetObjectLockConfigResponse
@@ -505,8 +492,7 @@ struct GetObjectTagsResponse : public Response {
 
   explicit GetObjectTagsResponse(error::Error err) : Response(std::move(err)) {}
 
-  explicit GetObjectTagsResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetObjectTagsResponse(const Response& resp) : Response(resp) {}
 
   ~GetObjectTagsResponse() = default;
 
@@ -526,7 +512,7 @@ struct IsObjectLegalHoldEnabledResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit IsObjectLegalHoldEnabledResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~IsObjectLegalHoldEnabledResponse() = default;
 };  // struct IsObjectLegalHoldEnabledResponse
@@ -540,8 +526,7 @@ struct GetObjectRetentionResponse : public Response {
   explicit GetObjectRetentionResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  explicit GetObjectRetentionResponse(const Response& resp)
-    : Response(resp) {}
+  explicit GetObjectRetentionResponse(const Response& resp) : Response(resp) {}
 
   ~GetObjectRetentionResponse() = default;
 };  // struct GetObjectRetentionResponse
@@ -558,7 +543,7 @@ struct GetPresignedObjectUrlResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit GetPresignedObjectUrlResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~GetPresignedObjectUrlResponse() = default;
 };  // struct GetPresignedObjectUrlResponse
@@ -573,7 +558,7 @@ struct GetPresignedPostFormDataResponse : public Response {
       : Response(std::move(err)) {}
 
   explicit GetPresignedPostFormDataResponse(const Response& resp)
-    : Response(resp) {}
+      : Response(resp) {}
 
   ~GetPresignedPostFormDataResponse() = default;
 };  // struct GetPresignedPostFormDataResponse

--- a/include/response.h
+++ b/include/response.h
@@ -41,7 +41,7 @@ struct Response {
   std::string object_name;
 
   Response();
-  Response(error::Error err) : err_(std::move(err)) {}
+  explicit Response(error::Error err) : err_(std::move(err)) {}
 
   Response(const Response& resp) = default;
   Response& operator=(const Response& resp) = default;
@@ -65,29 +65,65 @@ struct Response {
   error::Error err_;
 };  // struct Response
 
+
+#define MINIO_S3_DERIVE_FROM_RESPONSE(DerivedName)                                                  \
+  struct DerivedName : public Response {                                                            \
+    DerivedName() = default;                                                                        \
+    ~DerivedName() = default;                                                                       \
+                                                                                                    \
+    DerivedName(const DerivedName&) = default;                                                      \
+    DerivedName& operator =(const DerivedName&) = default;                                          \
+                                                                                                    \
+    DerivedName(DerivedName&&) = default;                                                           \
+    DerivedName& operator =(DerivedName&&) = default;                                               \
+                                                                                                    \
+    explicit DerivedName(error::Error err) : Response(std::move(err)) {}                            \
+    explicit DerivedName(const Response& resp) : Response(resp) {}                                  \
+  };
+
+#define MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(DerivedName)                                       \
+  struct DerivedName : public PutObjectResponse {                                                   \
+    DerivedName() = default;                                                                        \
+    ~DerivedName() = default;                                                                       \
+                                                                                                    \
+    DerivedName(const DerivedName&) = default;                                                      \
+    DerivedName& operator =(const DerivedName&) = default;                                          \
+                                                                                                    \
+    DerivedName(DerivedName&&) = default;                                                           \
+    DerivedName& operator =(DerivedName&&) = default;                                               \
+                                                                                                    \
+    explicit DerivedName(error::Error err) : PutObjectResponse(std::move(err)) {}                   \
+    explicit DerivedName(const PutObjectResponse& resp) : PutObjectResponse(resp) {}                \
+    explicit DerivedName(const Response& resp) : PutObjectResponse(resp) {}                         \
+                                                                                                    \
+    explicit DerivedName(const CompleteMultipartUploadResponse& resp) : PutObjectResponse(resp) {}  \
+  };
+
 struct GetRegionResponse : public Response {
   std::string region;
 
-  GetRegionResponse(std::string region) : region(std::move(region)) {}
+  explicit GetRegionResponse(std::string region) : region(std::move(region)) {}
 
-  GetRegionResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetRegionResponse(error::Error err) : Response(std::move(err)) {}
 
-  GetRegionResponse(const Response& resp) : Response(resp) {}
+  explicit GetRegionResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetRegionResponse() = default;
 };  // struct GetRegionResponse
 
-using MakeBucketResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(MakeBucketResponse)
 
 struct ListBucketsResponse : public Response {
   std::list<Bucket> buckets;
 
-  ListBucketsResponse(std::list<Bucket> buckets)
+  explicit ListBucketsResponse(std::list<Bucket> buckets)
       : buckets(std::move(buckets)) {}
 
-  ListBucketsResponse(error::Error err) : Response(std::move(err)) {}
+  explicit ListBucketsResponse(error::Error err) : Response(std::move(err)) {}
 
-  ListBucketsResponse(const Response& resp) : Response(resp) {}
+  explicit ListBucketsResponse(const Response& resp)
+    : Response(resp) {}
 
   ~ListBucketsResponse() = default;
 
@@ -97,18 +133,18 @@ struct ListBucketsResponse : public Response {
 struct BucketExistsResponse : public Response {
   bool exist = false;
 
-  BucketExistsResponse(bool exist) : exist(exist) {}
+  explicit BucketExistsResponse(bool exist) : exist(exist) {}
 
-  BucketExistsResponse(error::Error err) : Response(std::move(err)) {}
+  explicit BucketExistsResponse(error::Error err) : Response(std::move(err)) {}
 
-  BucketExistsResponse(const Response& resp) : Response(resp) {}
+  explicit BucketExistsResponse(const Response& resp)
+    : Response(resp) {}
 
   ~BucketExistsResponse() = default;
 };  // struct BucketExistsResponse
 
-using RemoveBucketResponse = Response;
-
-using AbortMultipartUploadResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(RemoveBucketResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(AbortMultipartUploadResponse)
 
 struct CompleteMultipartUploadResponse : public Response {
   std::string location;
@@ -117,10 +153,11 @@ struct CompleteMultipartUploadResponse : public Response {
 
   CompleteMultipartUploadResponse() = default;
 
-  CompleteMultipartUploadResponse(error::Error err)
+  explicit CompleteMultipartUploadResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  CompleteMultipartUploadResponse(const Response& resp) : Response(resp) {}
+  explicit CompleteMultipartUploadResponse(const Response& resp)
+    : Response(resp) {}
 
   ~CompleteMultipartUploadResponse() = default;
 
@@ -131,12 +168,14 @@ struct CompleteMultipartUploadResponse : public Response {
 struct CreateMultipartUploadResponse : public Response {
   std::string upload_id;
 
-  CreateMultipartUploadResponse(std::string upload_id)
+  explicit CreateMultipartUploadResponse(std::string upload_id)
       : upload_id(std::move(upload_id)) {}
 
-  CreateMultipartUploadResponse(error::Error err) : Response(std::move(err)) {}
+  explicit CreateMultipartUploadResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  CreateMultipartUploadResponse(const Response& resp) : Response(resp) {}
+  explicit CreateMultipartUploadResponse(const Response& resp)
+    : Response(resp) {}
 
   ~CreateMultipartUploadResponse() = default;
 };  // struct CreateMultipartUploadResponse
@@ -147,19 +186,19 @@ struct PutObjectResponse : public Response {
 
   PutObjectResponse() = default;
 
-  PutObjectResponse(error::Error err) : Response(std::move(err)) {}
+  explicit PutObjectResponse(error::Error err) : Response(std::move(err)) {}
 
-  PutObjectResponse(const Response& resp) : Response(resp) {}
+  explicit PutObjectResponse(const Response& resp)
+    : Response(resp) {}
 
-  PutObjectResponse(const CompleteMultipartUploadResponse& resp)
+  explicit PutObjectResponse(const CompleteMultipartUploadResponse& resp)
       : Response(resp), etag(resp.etag), version_id(resp.version_id) {}
 
   ~PutObjectResponse() = default;
 };  // struct PutObjectResponse
 
-using UploadPartResponse = PutObjectResponse;
-
-using UploadPartCopyResponse = PutObjectResponse;
+MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(UploadPartResponse)
+MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(UploadPartCopyResponse)
 
 struct StatObjectResponse : public Response {
   std::string version_id;
@@ -174,18 +213,17 @@ struct StatObjectResponse : public Response {
 
   StatObjectResponse() = default;
 
-  StatObjectResponse(error::Error err) : Response(std::move(err)) {}
+  explicit StatObjectResponse(error::Error err) : Response(std::move(err)) {}
 
-  StatObjectResponse(const Response& resp) : Response(resp) {}
+  explicit StatObjectResponse(const Response& resp)
+    : Response(resp) {}
 
   ~StatObjectResponse() = default;
 };  // struct StatObjectResponse
 
-using RemoveObjectResponse = Response;
-
-using DownloadObjectResponse = Response;
-
-using GetObjectResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(RemoveObjectResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DownloadObjectResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(GetObjectResponse)
 
 struct Item : public Response {
   std::string etag;  // except DeleteMarker
@@ -204,9 +242,10 @@ struct Item : public Response {
 
   Item() = default;
 
-  Item(error::Error err) : Response(std::move(err)) {}
+  explicit Item(error::Error err) : Response(std::move(err)) {}
 
-  Item(const Response& resp) : Response(resp) {}
+  explicit Item(const Response& resp)
+    : Response(resp) {}
 
   ~Item() = default;
 };  // struct Item
@@ -239,20 +278,19 @@ struct ListObjectsResponse : public Response {
 
   ListObjectsResponse() = default;
 
-  ListObjectsResponse(error::Error err) : Response(std::move(err)) {}
+  explicit ListObjectsResponse(error::Error err) : Response(std::move(err)) {}
 
-  ListObjectsResponse(const Response& resp) : Response(resp) {}
+  explicit ListObjectsResponse(const Response& resp)
+    : Response(resp) {}
 
   ~ListObjectsResponse() = default;
 
   static ListObjectsResponse ParseXML(std::string_view data, bool version);
 };  // struct ListObjectsResponse
 
-using CopyObjectResponse = PutObjectResponse;
-
-using ComposeObjectResponse = PutObjectResponse;
-
-using UploadObjectResponse = PutObjectResponse;
+MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(CopyObjectResponse)
+MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(ComposeObjectResponse)
+MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(UploadObjectResponse)
 
 struct DeletedObject : public Response {
   std::string name;
@@ -269,9 +307,10 @@ struct DeleteError : public Response {
 
   DeleteError() = default;
 
-  DeleteError(error::Error err) : Response(std::move(err)) {}
+  explicit DeleteError(error::Error err) : Response(std::move(err)) {}
 
-  DeleteError(const Response& resp) : Response(resp) {}
+  explicit DeleteError(const Response& resp)
+    : Response(resp) {}
 
   ~DeleteError() = default;
 };  // struct DeleteError
@@ -282,71 +321,76 @@ struct RemoveObjectsResponse : public Response {
 
   RemoveObjectsResponse() = default;
 
-  RemoveObjectsResponse(error::Error err) : Response(std::move(err)) {}
+  explicit RemoveObjectsResponse(error::Error err) : Response(std::move(err)) {}
 
-  RemoveObjectsResponse(const Response& resp) : Response(resp) {}
+  explicit RemoveObjectsResponse(const Response& resp)
+    : Response(resp) {}
 
   ~RemoveObjectsResponse() = default;
 
   static RemoveObjectsResponse ParseXML(std::string_view data);
 };  // struct RemoveObjectsResponse
 
-using SelectObjectContentResponse = Response;
-
-using ListenBucketNotificationResponse = Response;
-
-using DeleteBucketPolicyResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SelectObjectContentResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(ListenBucketNotificationResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteBucketPolicyResponse)
 
 struct GetBucketPolicyResponse : public Response {
   std::string policy;
 
-  GetBucketPolicyResponse(std::string policy) : policy(std::move(policy)) {}
+  explicit GetBucketPolicyResponse(std::string policy)
+      : policy(std::move(policy)) {}
 
-  GetBucketPolicyResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketPolicyResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetBucketPolicyResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketPolicyResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetBucketPolicyResponse() = default;
 };  // struct GetBucketPolicyResponse
 
-using SetBucketPolicyResponse = Response;
-
-using DeleteBucketNotificationResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketPolicyResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteBucketNotificationResponse)
 
 struct GetBucketNotificationResponse : public Response {
   NotificationConfig config;
 
-  GetBucketNotificationResponse(NotificationConfig config)
+  explicit GetBucketNotificationResponse(NotificationConfig config)
       : config(std::move(config)) {}
 
-  GetBucketNotificationResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketNotificationResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetBucketNotificationResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketNotificationResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetBucketNotificationResponse() = default;
 
   static GetBucketNotificationResponse ParseXML(std::string_view data);
 };  // struct GetBucketNotificationResponse
 
-using SetBucketNotificationResponse = Response;
-
-using DeleteBucketEncryptionResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketNotificationResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteBucketEncryptionResponse)
 
 struct GetBucketEncryptionResponse : public Response {
   SseConfig config;
 
-  GetBucketEncryptionResponse(SseConfig config) : config(std::move(config)) {}
+  explicit GetBucketEncryptionResponse(SseConfig config)
+      : config(std::move(config)) {}
 
-  GetBucketEncryptionResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketEncryptionResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetBucketEncryptionResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketEncryptionResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetBucketEncryptionResponse() = default;
 
   static GetBucketEncryptionResponse ParseXML(std::string_view data);
 };  // struct GetBucketEncryptionResponse
 
-using SetBucketEncryptionResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketEncryptionResponse)
 
 struct GetBucketVersioningResponse : public Response {
   Boolean status;
@@ -354,9 +398,11 @@ struct GetBucketVersioningResponse : public Response {
 
   GetBucketVersioningResponse() = default;
 
-  GetBucketVersioningResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketVersioningResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetBucketVersioningResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketVersioningResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetBucketVersioningResponse() = default;
 
@@ -366,50 +412,53 @@ struct GetBucketVersioningResponse : public Response {
   }
 
   std::string MfaDelete() const {
-    if (!mfa_delete) return {};
+    if (!mfa_delete) {
+      return {};
+    }
     return mfa_delete.Get() ? "Enabled" : "Disabled";
   }
 };  // struct GetBucketVersioningResponse
 
-using SetBucketVersioningResponse = Response;
-
-using DeleteBucketReplicationResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketVersioningResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteBucketReplicationResponse)
 
 struct GetBucketReplicationResponse : public Response {
   ReplicationConfig config;
 
-  GetBucketReplicationResponse(ReplicationConfig config)
+  explicit GetBucketReplicationResponse(ReplicationConfig config)
       : config(std::move(config)) {}
 
-  GetBucketReplicationResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketReplicationResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetBucketReplicationResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketReplicationResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetBucketReplicationResponse() = default;
 
   static GetBucketReplicationResponse ParseXML(std::string_view data);
 };  // struct GetBucketReplicationResponse
 
-using SetBucketReplicationResponse = Response;
-
-using DeleteBucketLifecycleResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketReplicationResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteBucketLifecycleResponse)
 
 struct GetBucketLifecycleResponse : public Response {
   LifecycleConfig config;
 
-  GetBucketLifecycleResponse(LifecycleConfig config)
+  explicit GetBucketLifecycleResponse(LifecycleConfig config)
       : config(std::move(config)) {}
 
-  GetBucketLifecycleResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketLifecycleResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetBucketLifecycleResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketLifecycleResponse(const Response& resp)
+    : Response(resp) {}
 
   static GetBucketLifecycleResponse ParseXML(std::string_view data);
 };  // struct GetBucketLifecycleResponse
 
-using SetBucketLifecycleResponse = Response;
-
-using DeleteBucketTagsResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketLifecycleResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteBucketTagsResponse)
 
 struct GetBucketTagsResponse : public Response {
   std::map<std::string, std::string> tags;
@@ -417,35 +466,36 @@ struct GetBucketTagsResponse : public Response {
   GetBucketTagsResponse(std::map<std::string, std::string> tags)
       : tags(std::move(tags)) {}
 
-  GetBucketTagsResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetBucketTagsResponse(error::Error err) : Response(std::move(err)) {}
 
-  GetBucketTagsResponse(const Response& resp) : Response(resp) {}
+  explicit GetBucketTagsResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetBucketTagsResponse() = default;
 
   static GetBucketTagsResponse ParseXML(std::string_view data);
 };  // struct GetBucketTagsResponse
 
-using SetBucketTagsResponse = Response;
-
-using DeleteObjectLockConfigResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetBucketTagsResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteObjectLockConfigResponse)
 
 struct GetObjectLockConfigResponse : public Response {
   ObjectLockConfig config;
 
-  GetObjectLockConfigResponse(ObjectLockConfig config)
+  explicit GetObjectLockConfigResponse(ObjectLockConfig config)
       : config(std::move(config)) {}
 
-  GetObjectLockConfigResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetObjectLockConfigResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetObjectLockConfigResponse(const Response& resp) : Response(resp) {}
+  explicit GetObjectLockConfigResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetObjectLockConfigResponse() = default;
 };  // struct GetObjectLockConfigResponse
 
-using SetObjectLockConfigResponse = Response;
-
-using DeleteObjectTagsResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetObjectLockConfigResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DeleteObjectTagsResponse)
 
 struct GetObjectTagsResponse : public Response {
   std::map<std::string, std::string> tags;
@@ -453,30 +503,30 @@ struct GetObjectTagsResponse : public Response {
   GetObjectTagsResponse(std::map<std::string, std::string> tags)
       : tags(std::move(tags)) {}
 
-  GetObjectTagsResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetObjectTagsResponse(error::Error err) : Response(std::move(err)) {}
 
-  GetObjectTagsResponse(const Response& resp) : Response(resp) {}
+  explicit GetObjectTagsResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetObjectTagsResponse() = default;
 
   static GetObjectTagsResponse ParseXML(std::string_view data);
 };  // struct GetObjectTagsResponse
 
-using SetObjectTagsResponse = Response;
-
-using EnableObjectLegalHoldResponse = Response;
-
-using DisableObjectLegalHoldResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetObjectTagsResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(EnableObjectLegalHoldResponse)
+MINIO_S3_DERIVE_FROM_RESPONSE(DisableObjectLegalHoldResponse)
 
 struct IsObjectLegalHoldEnabledResponse : public Response {
   bool enabled = false;
 
-  IsObjectLegalHoldEnabledResponse(bool enabled) : enabled(enabled) {}
+  explicit IsObjectLegalHoldEnabledResponse(bool enabled) : enabled(enabled) {}
 
-  IsObjectLegalHoldEnabledResponse(error::Error err)
+  explicit IsObjectLegalHoldEnabledResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  IsObjectLegalHoldEnabledResponse(const Response& resp) : Response(resp) {}
+  explicit IsObjectLegalHoldEnabledResponse(const Response& resp)
+    : Response(resp) {}
 
   ~IsObjectLegalHoldEnabledResponse() = default;
 };  // struct IsObjectLegalHoldEnabledResponse
@@ -487,23 +537,28 @@ struct GetObjectRetentionResponse : public Response {
 
   GetObjectRetentionResponse() = default;
 
-  GetObjectRetentionResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetObjectRetentionResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetObjectRetentionResponse(const Response& resp) : Response(resp) {}
+  explicit GetObjectRetentionResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetObjectRetentionResponse() = default;
 };  // struct GetObjectRetentionResponse
 
-using SetObjectRetentionResponse = Response;
+MINIO_S3_DERIVE_FROM_RESPONSE(SetObjectRetentionResponse)
 
 struct GetPresignedObjectUrlResponse : public Response {
   std::string url;
 
-  GetPresignedObjectUrlResponse(std::string url) : url(std::move(url)) {}
+  explicit GetPresignedObjectUrlResponse(std::string url)
+      : url(std::move(url)) {}
 
-  GetPresignedObjectUrlResponse(error::Error err) : Response(std::move(err)) {}
+  explicit GetPresignedObjectUrlResponse(error::Error err)
+      : Response(std::move(err)) {}
 
-  GetPresignedObjectUrlResponse(const Response& resp) : Response(resp) {}
+  explicit GetPresignedObjectUrlResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetPresignedObjectUrlResponse() = default;
 };  // struct GetPresignedObjectUrlResponse
@@ -514,13 +569,17 @@ struct GetPresignedPostFormDataResponse : public Response {
   GetPresignedPostFormDataResponse(std::map<std::string, std::string> form_data)
       : form_data(std::move(form_data)) {}
 
-  GetPresignedPostFormDataResponse(error::Error err)
+  explicit GetPresignedPostFormDataResponse(error::Error err)
       : Response(std::move(err)) {}
 
-  GetPresignedPostFormDataResponse(const Response& resp) : Response(resp) {}
+  explicit GetPresignedPostFormDataResponse(const Response& resp)
+    : Response(resp) {}
 
   ~GetPresignedPostFormDataResponse() = default;
 };  // struct GetPresignedPostFormDataResponse
+
+#undef MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE
+#undef MINIO_S3_DERIVE_FROM_RESPONSE
 }  // namespace s3
 }  // namespace minio
 

--- a/include/select.h
+++ b/include/select.h
@@ -57,7 +57,7 @@ class SelectHandler {
   bool process(const http::DataFunctionArgs& args, bool& cont);
 
  public:
-  SelectHandler(SelectResultFunction result_func)
+  explicit SelectHandler(SelectResultFunction result_func)
       : result_func_(std::move(result_func)) {}
 
   ~SelectHandler() = default;

--- a/include/sse.h
+++ b/include/sse.h
@@ -39,7 +39,7 @@ class Sse {
 
 class SseCustomerKey : public Sse {
  public:
-  SseCustomerKey(std::string_view key);
+  explicit SseCustomerKey(std::string_view key);
   virtual ~SseCustomerKey();
 
   virtual bool TlsRequired() const override;

--- a/include/types.h
+++ b/include/types.h
@@ -297,7 +297,7 @@ struct SelectResult {
 
   SelectResult() : ended(true) {}
 
-  SelectResult(error::Error err) : err(std::move(err)), ended(true) {}
+  explicit SelectResult(error::Error err) : err(std::move(err)), ended(true) {}
 
   SelectResult(long int bytes_scanned, long int bytes_processed,
                long int bytes_returned)
@@ -412,7 +412,7 @@ struct FilterValue {
  public:
   FilterValue() = default;
 
-  FilterValue(std::string value)
+  explicit FilterValue(std::string value)
       : value_(std::move(value)), is_value_set_(true) {}
 
   ~FilterValue() = default;
@@ -426,7 +426,8 @@ struct PrefixFilterRule : public FilterValue {
 
   PrefixFilterRule() = default;
 
-  PrefixFilterRule(std::string value) : FilterValue(std::move(value)) {}
+  explicit PrefixFilterRule(std::string value)
+      : FilterValue(std::move(value)) {}
 
   ~PrefixFilterRule() = default;
 };  // struct PrefixFilterRule
@@ -436,7 +437,8 @@ struct SuffixFilterRule : public FilterValue {
 
   SuffixFilterRule() = default;
 
-  SuffixFilterRule(std::string value) : FilterValue(std::move(value)) {}
+  explicit SuffixFilterRule(std::string value)
+      : FilterValue(std::move(value)) {}
 
   ~SuffixFilterRule() = default;
 };  // struct SuffixFilterRule
@@ -514,7 +516,8 @@ struct Prefix {
  public:
   Prefix() = default;
 
-  Prefix(std::string value) : value_(std::move(value)), is_set_(true) {}
+  explicit Prefix(std::string value)
+      : value_(std::move(value)), is_set_(true) {}
 
   ~Prefix() = default;
 
@@ -534,7 +537,19 @@ struct Integer {
  public:
   Integer() = default;
 
-  Integer(int value) : value_(value), is_set_(true) {}
+  explicit Integer(int value) : value_(value), is_set_(true) {}
+
+  Integer& operator=(int value) {
+    value_ = value;
+    is_set_ = true;
+    return *this;
+  }
+
+  Integer(const Integer&) = default;
+  Integer& operator=(const Integer&) = default;
+
+  Integer(Integer&&) = default;
+  Integer& operator=(Integer&&) = default;
 
   ~Integer() = default;
 
@@ -554,7 +569,19 @@ struct Boolean {
  public:
   Boolean() = default;
 
-  Boolean(bool value) : value_(value), is_set_(true) {}
+  explicit Boolean(bool value) : value_(value), is_set_(true) {}
+
+  Boolean& operator=(bool value) {
+    value_ = value;
+    is_set_ = true;
+    return *this;
+  }
+
+  Boolean(const Boolean&) = default;
+  Boolean& operator=(const Boolean&) = default;
+
+  Boolean(Boolean&&) = default;
+  Boolean& operator=(Boolean&&) = default;
 
   ~Boolean() = default;
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -115,7 +115,7 @@ class UtcTime {
   long usecs_ = 0L;
 
   static std::tm auxLocaltime(const std::time_t& time);
-  std::tm getBrokenDownTime() const { return auxLocaltime(secs_); } 
+  std::tm getBrokenDownTime() const { return auxLocaltime(secs_); }
 
  public:
   UtcTime() = default;

--- a/include/utils.h
+++ b/include/utils.h
@@ -50,7 +50,7 @@ unsigned long CRC32(std::string_view str);
 unsigned int Int(std::string_view str);
 
 // FormatTime formats time as per format.
-std::string FormatTime(const std::tm* time, const char* format);
+std::string FormatTime(const std::tm& time, const char* format);
 
 // StringToBool converts string to bool.
 bool StringToBool(const std::string& str);

--- a/include/utils.h
+++ b/include/utils.h
@@ -114,7 +114,8 @@ class UtcTime {
   std::time_t secs_ = {};
   long usecs_ = 0L;
 
-  std::tm* getBrokenDownTime() const;
+  static std::tm auxLocaltime(const std::time_t& time);
+  std::tm getBrokenDownTime() const { return auxLocaltime(secs_); } 
 
  public:
   UtcTime() = default;

--- a/src/args.cc
+++ b/src/args.cc
@@ -246,6 +246,11 @@ minio::s3::ListObjectsV1Args::ListObjectsV1Args(ListObjectsArgs args) {
   this->marker = args.marker;
 }
 
+minio::s3::ListObjectsV1Args& minio::s3::ListObjectsV1Args::operator=(
+    ListObjectsArgs args) {
+  return this->operator=(ListObjectsV1Args(std::move(args)));
+}
+
 minio::s3::ListObjectsV2Args::ListObjectsV2Args() {}
 
 minio::s3::ListObjectsV2Args::ListObjectsV2Args(ListObjectsArgs args) {
@@ -263,6 +268,11 @@ minio::s3::ListObjectsV2Args::ListObjectsV2Args(ListObjectsArgs args) {
   this->include_user_metadata = args.include_user_metadata;
 }
 
+minio::s3::ListObjectsV2Args& minio::s3::ListObjectsV2Args::operator=(
+    ListObjectsArgs args) {
+  return this->operator=(ListObjectsV2Args(std::move(args)));
+}
+
 minio::s3::ListObjectVersionsArgs::ListObjectVersionsArgs() {}
 
 minio::s3::ListObjectVersionsArgs::ListObjectVersionsArgs(
@@ -277,6 +287,11 @@ minio::s3::ListObjectVersionsArgs::ListObjectVersionsArgs(
   this->prefix = args.prefix;
   this->key_marker = args.key_marker;
   this->version_id_marker = args.version_id_marker;
+}
+
+minio::s3::ListObjectVersionsArgs& minio::s3::ListObjectVersionsArgs::operator=(
+    ListObjectsArgs args) {
+  return this->operator=(ListObjectVersionsArgs(args));
 }
 
 minio::s3::PutObjectArgs::PutObjectArgs(std::istream& istream, long object_size,

--- a/src/credentials.cc
+++ b/src/credentials.cc
@@ -33,8 +33,9 @@ minio::creds::Credentials minio::creds::Credentials::ParseXML(
     std::string_view data, const std::string& root) {
   pugi::xml_document xdoc;
   pugi::xml_parse_result result = xdoc.load_string(data.data());
-  if (!result) return Credentials{error::Error("unable to parse XML")};
-
+  if (!result) {
+    return error::make<Credentials>("unable to parse XML");
+  }
   auto credentials = xdoc.select_node((root + "/Credentials").c_str());
 
   auto text = credentials.node().select_node("AccessKeyId/text()");

--- a/src/types.cc
+++ b/src/types.cc
@@ -479,7 +479,9 @@ minio::error::Error minio::s3::LifecycleRule::Validate() const {
         "specified in a rule");
   }
 
-  if (!filter) return error::Error("valid filter must be provided");
+  if (!filter) {
+    return error::Error("valid filter must be provided");
+  }
 
   if (expiration_expired_object_delete_marker) {
     if (expiration_date || expiration_days) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -23,15 +23,14 @@
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/types.h>
+#include <time.h>
 #include <zconf.h>
 #include <zlib.h>
 
 #include <algorithm>
 #include <cctype>
-#include <time.h>
 #include <chrono>
 #include <clocale>
-#include <memory>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -45,6 +44,7 @@
 #include <list>
 #include <locale>
 #include <map>
+#include <memory>
 #include <ostream>
 #include <regex>
 #include <sstream>

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -320,7 +320,7 @@ std::tm minio::utils::UtcTime::auxLocaltime(const std::time_t& time) {
 #ifdef _WIN32
   localtime_s(&result, &time);
 #else
-  localtime_r(&result, &time); //PWTODO    
+  localtime_r(&time, &result);
 #endif
   return result;
 }

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <time.h>
 #include <chrono>
 #include <clocale>
 #include <cmath>

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -31,6 +31,7 @@
 #include <time.h>
 #include <chrono>
 #include <clocale>
+#include <memory>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
Complete the rework with the following improvements:
1. Get rid of converting constructors by replacing them with explicit ones.
2. Make all `Response`-derived types distinct to allow type-based template dispatching and dynamic type-aware switches (a.k.a. reflections) to work predictably.
3. `std::localtime` is not thread-safe. Replaced with localtime_r and localtime_s wrapped within a helper function hiding the OS implementation details.
4. Provided more explicitly defaulted entities (constructors, assignment operators).
5. Various minor fixes.