### PR TITLE
Moved C++ headers to minio-cpp subdirectory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,34 @@ permissions:
   contents: read
 
 jobs:
+  coding-style:
+    name: "Coding Style Check"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies if Ubuntu
+      run: |
+        wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main' | sudo tee -a /etc/apt/sources.list
+        sudo apt-get -qy update
+        sudo apt-get -qy install clang-format-18
+        clang-format-18 --version
+
+    - name: Coding Style Check
+      shell: bash
+      run: |
+        CLANG_FORMAT=clang-format-18 ./check-style.sh
+
   build:
-    name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
         config:
         - {
             name: "Ubuntu_Latest_GCC",
-            os: Ubuntu-latest,
+            os: ubuntu-latest,
             build_type: "Release",
             cc: "gcc",
             cxx: "g++"
@@ -45,8 +63,20 @@ jobs:
             cxx: "cl"
           }
 
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout minio-cpp
+      uses: actions/checkout@v4
+      with:
+        path: "minio-cpp"
+
+    - name: Checkout vcpkg
+      uses: actions/checkout@v4
+      with:
+        repository: microsoft/vcpkg
+        path: "vcpkg"
 
     - name: Print env
       run: |
@@ -57,22 +87,20 @@ jobs:
       if: startsWith(matrix.config.name, 'Ubuntu_Latest_GCC')
       run: |
         wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main' | sudo tee -a /etc/apt/sources.list
+        echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-18 main' | sudo tee -a /etc/apt/sources.list
         sudo apt-get -qy update
-        sudo apt-get -qy install cmake clang-format-14
+        sudo apt-get -qy install cmake
         wget --quiet https://dl.min.io/server/minio/release/linux-amd64/minio
         chmod +x minio
         cmake --version
-        clang-format --version
         ./minio --version
 
     - name: Install dependencies if macOS
       if: startsWith(matrix.config.os, 'macos')
       run: |
-        brew install pkg-config cmake clang-format minio/stable/minio
+        brew install pkg-config cmake minio/stable/minio
         cmake --version
         minio --version
-        clang-format --version
 
     - name: Install dependencies if Windows
       shell: bash
@@ -83,35 +111,21 @@ jobs:
         chmod +x minio.exe
         cmake --version
 
-    - name: Install vcpkg
-      shell: bash
-      run: |
-        mkdir -p ~/.vcpkg
-        touch ~/.vcpkg/vcpkg.path.txt
-        wget --quiet -O vcpkg-master.zip https://github.com/microsoft/vcpkg/archive/refs/heads/master.zip
-        unzip -qq vcpkg-master.zip
-        ./vcpkg-master/bootstrap-vcpkg.sh
-        ./vcpkg-master/vcpkg integrate install
-        ./vcpkg-master/vcpkg install
-
-    - name: C++ Style check if not Windows
-      if: ${{ !startsWith(matrix.config.os, 'windows') }}
-      shell: bash
-      run: |
-        ./check-style.sh
-
     - name: Configure and Build
       shell: bash
       run: |
-        cmake -B ./build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DCMAKE_TOOLCHAIN_FILE=./vcpkg-master/scripts/buildsystems/vcpkg.cmake -DMINIO_CPP_TEST:BOOL=ON
-        cmake --build ./build --config ${{ matrix.config.build_type }} -j 4
+        ./vcpkg/bootstrap-vcpkg.sh
+        cd minio-cpp
+        ../vcpkg/vcpkg install
+        cmake . -B ./build -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake -DMINIO_CPP_TEST:BOOL=ON
+        cmake --build ./build --config ${{matrix.config.build_type}} -j 4
 
     - name: Start MinIO server if Ubuntu
       if: startsWith(matrix.config.name, 'Ubuntu_Latest_GCC')
       run: |
         mkdir -p ~/.minio/certs
-        cp ./tests/public.crt ./tests/private.key ~/.minio/certs/
-        sudo cp ./tests/public.crt /usr/local/share/ca-certificates/
+        cp ./minio-cpp/tests/public.crt ./minio-cpp/tests/private.key ~/.minio/certs/
+        sudo cp ./minio-cpp/tests/public.crt /usr/local/share/ca-certificates/
         sudo update-ca-certificates
         MINIO_CI_CD=true ./minio server /tmp/test-xl/{1...4}/ &
         sleep 10
@@ -127,29 +141,28 @@ jobs:
       shell: bash
       run: |
         mkdir -p ~/.minio/certs
-        cp ./tests/public.crt ./tests/private.key ~/.minio/certs/
-        certutil -addstore -f "ROOT" ./tests/public.crt
+        cp ./minio-cpp/tests/public.crt ./minio-cpp/tests/private.key ~/.minio/certs/
+        certutil -addstore -f "ROOT" ./minio-cpp/tests/public.crt
         MINIO_CI_CD=true ./minio.exe server test-xl/{1...4}/ &
         sleep 10
 
     - name: Run tests if Ubuntu
       if: startsWith(matrix.config.name, 'Ubuntu_Latest_GCC')
       run: |
-        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./build/tests
+        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./minio-cpp/build/tests
 
     - name: Run tests if macOS
       if: startsWith(matrix.config.name, 'macos')
       run: |
-        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ./build/tests
+        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ./minio-cpp/build/tests
 
     - name: Run tests if Windows
       shell: bash
       if: startsWith(matrix.config.os, 'windows')
       run: |
-        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./build/Release/tests.exe
+        SERVER_ENDPOINT=localhost:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin ENABLE_HTTPS=1 ./minio-cpp/build/Release/tests.exe
 
     - name: Run CMake test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{ matrix.config.build_type }}
+      run: |
+        cd minio-cpp/build
+        ctest -C ${{ matrix.config.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.10)
 cmake_policy(SET CMP0091 NEW)
 
@@ -97,21 +100,21 @@ set(MINIO_CPP_SOURCES
 )
 
 set(MINIO_CPP_HEADERS
-  include/args.h
-  include/baseclient.h
-  include/client.h
-  include/config.h
-  include/credentials.h
-  include/error.h
-  include/http.h
-  include/providers.h
-  include/request.h
-  include/response.h
-  include/select.h
-  include/signer.h
-  include/sse.h
-  include/types.h
-  include/utils.h
+  include/miniocpp/args.h
+  include/miniocpp/baseclient.h
+  include/miniocpp/client.h
+  include/miniocpp/config.h
+  include/miniocpp/credentials.h
+  include/miniocpp/error.h
+  include/miniocpp/http.h
+  include/miniocpp/providers.h
+  include/miniocpp/request.h
+  include/miniocpp/response.h
+  include/miniocpp/select.h
+  include/miniocpp/signer.h
+  include/miniocpp/sse.h
+  include/miniocpp/types.h
+  include/miniocpp/utils.h
 )
 
 add_library(miniocpp STATIC ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Typically `minio-cpp` will be part of dependencies specified in `vcpkg.json` fil
 
 ## Hacking minio-cpp
 
-In order to run minio-cpp tests and examples, you can do the following assuming `VCPKG_ROOT` points to a `vcpkg` installation:
+In order to run minio-cpp tests and examples, you can do the following assuming `VCPKG_ROOT` points to a valid `vcpkg` installation:
 
 ```bash
 $ git clone https://github.com/minio/minio-cpp
@@ -58,11 +58,10 @@ The examples above assumed that you have `vcpkg` already installed and you have 
 ```bash
 $ git clone https://github.com/minio/minio-cpp
 $ cd minio-cpp
-$ wget --quiet -O vcpkg-master.zip https://github.com/microsoft/vcpkg/archive/refs/heads/master.zip
-$ unzip -qq vcpkg-master.zip
-$ ./vcpkg-master/bootstrap-vcpkg.sh
-$ ./vcpkg-master/vcpkg integrate install
-$ cmake . -B ./build/Debug -DCMAKE_BUILD_TYPE=Debug -DMINIO_CPP_TEST=ON -DCMAKE_TOOLCHAIN_FILE=./vcpkg-master/scripts/buildsystems/vcpkg.cmake
+$ git clone https://github.com/microsoft/vcpkg.git
+$ ./vcpkg/bootstrap-vcpkg.sh
+$ ./vcpkg/vcpkg install
+$ cmake . -B ./build/Debug -DCMAKE_BUILD_TYPE=Debug -DMINIO_CPP_TEST=ON -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
 $ cmake --build ./build/Debug
 ```
 

--- a/check-style.sh
+++ b/check-style.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-function clang_format() {
-    echo "verifying 'clang-format --output-replacements-xml --style=Google $@'"
-    if clang-format --output-replacements-xml --style=Google "$@" | grep -q '<replacement '; then
+if [ -z "${CLANG_FORMAT}" ]; then
+  CLANG_FORMAT="clang-format"
+fi
+
+function do_clang_format() {
+    echo "verifying '${CLANG_FORMAT} --output-replacements-xml --style=Google $@'"
+    if ${CLANG_FORMAT} --output-replacements-xml --style=Google "$@" | grep -q '<replacement '; then
         echo "ERROR:" "$@" "not in Google C/C++ style"
         echo "To fix formatting run"
-        echo "$ clang-format -i --style=Google" "$@"
+        echo "$ ${CLANG_FORMAT} -i --style=Google" "$@"
         return 255
     fi
 }
@@ -14,7 +18,7 @@ tmpfile="tmpfile.$RANDOM"
 find src include examples tests -iname "*.cc" -o -iname "*.h" > "$tmpfile"
 ec=0
 while read -r file; do
-    if ! clang_format "$file"; then
+    if ! do_clang_format "$file"; then
         ec=255
     fi
 done < "$tmpfile"

--- a/examples/BucketExists.cc
+++ b/examples/BucketExists.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/ComposeObject.cc
+++ b/examples/ComposeObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Composeright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/CopyObject.cc
+++ b/examples/CopyObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteBucketEncryption.cc
+++ b/examples/DeleteBucketEncryption.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteBucketLifecycle.cc
+++ b/examples/DeleteBucketLifecycle.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteBucketNotification.cc
+++ b/examples/DeleteBucketNotification.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteBucketPolicy.cc
+++ b/examples/DeleteBucketPolicy.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteBucketReplication.cc
+++ b/examples/DeleteBucketReplication.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteBucketTags.cc
+++ b/examples/DeleteBucketTags.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteObjectLockConfig.cc
+++ b/examples/DeleteObjectLockConfig.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DeleteObjectTags.cc
+++ b/examples/DeleteObjectTags.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DisableObjectLegalHold.cc
+++ b/examples/DisableObjectLegalHold.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/DownloadObject.cc
+++ b/examples/DownloadObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/EnableObjectLegalHold.cc
+++ b/examples/EnableObjectLegalHold.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetBucketEncryption.cc
+++ b/examples/GetBucketEncryption.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetBucketLifecycle.cc
+++ b/examples/GetBucketLifecycle.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetBucketNotification.cc
+++ b/examples/GetBucketNotification.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetBucketPolicy.cc
+++ b/examples/GetBucketPolicy.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetBucketReplication.cc
+++ b/examples/GetBucketReplication.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetBucketTags.cc
+++ b/examples/GetBucketTags.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.
@@ -37,8 +39,7 @@ int main() {
   if (resp) {
     std::cout << "Bucket tags: " << std::endl;
     for (auto& [key, value] : resp.tags) {
-      std::cout << "Key: " << key << ", "
-                << "Value: " << value << std::endl;
+      std::cout << "Key: " << key << ", " << "Value: " << value << std::endl;
     }
   } else {
     std::cout << "unable to get bucket tags; " << resp.Error().String()

--- a/examples/GetBucketVersioning.cc
+++ b/examples/GetBucketVersioning.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetObject.cc
+++ b/examples/GetObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetObjectLockConfig.cc
+++ b/examples/GetObjectLockConfig.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetObjectProgress.cc
+++ b/examples/GetObjectProgress.cc
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetObjectRetention.cc
+++ b/examples/GetObjectRetention.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetObjectTags.cc
+++ b/examples/GetObjectTags.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.
@@ -38,8 +40,7 @@ int main() {
   if (resp) {
     std::cout << "Object tags: " << std::endl;
     for (auto& [key, value] : resp.tags) {
-      std::cout << "Key: " << key << ", "
-                << "Value: " << value << std::endl;
+      std::cout << "Key: " << key << ", " << "Value: " << value << std::endl;
     }
   } else {
     std::cout << "unable to get object tags; " << resp.Error().String()

--- a/examples/GetPresignedObjectUrl.cc
+++ b/examples/GetPresignedObjectUrl.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/GetPresignedPostFormData.cc
+++ b/examples/GetPresignedPostFormData.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/IsObjectLegalHoldEnabled.cc
+++ b/examples/IsObjectLegalHoldEnabled.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/ListBuckets.cc
+++ b/examples/ListBuckets.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/ListObjects.cc
+++ b/examples/ListObjects.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/ListenBucketNotification.cc
+++ b/examples/ListenBucketNotification.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/MakeBucket.cc
+++ b/examples/MakeBucket.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/PutObject.cc
+++ b/examples/PutObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <miniocpp/args.h>
+#include <miniocpp/client.h>
+#include <miniocpp/providers.h>
+#include <miniocpp/request.h>
+#include <miniocpp/response.h>
 
 #include <fstream>
 #include <iosfwd>
 #include <iostream>
 #include <ostream>
-
-#include "args.h"
-#include "client.h"
-#include "providers.h"
-#include "request.h"
-#include "response.h"
 
 int main() {
   // Create S3 base URL.

--- a/examples/PutObjectProgress.cc
+++ b/examples/PutObjectProgress.cc
@@ -12,18 +12,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <miniocpp/args.h>
+#include <miniocpp/client.h>
+#include <miniocpp/providers.h>
+#include <miniocpp/request.h>
+#include <miniocpp/response.h>
 
 #include <fstream>
 #include <iosfwd>
 #include <iostream>
 #include <ostream>
-
-#include "args.h"
-#include "client.h"
-#include "http.h"
-#include "providers.h"
-#include "request.h"
-#include "response.h"
 
 int main() {
   // Create S3 base URL.

--- a/examples/RemoveBucket.cc
+++ b/examples/RemoveBucket.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/RemoveObject.cc
+++ b/examples/RemoveObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/RemoveObjects.cc
+++ b/examples/RemoveObjects.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SelectObjectContent.cc
+++ b/examples/SelectObjectContent.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
-#include "select.h"
+#include <miniocpp/client.h>
+#include <miniocpp/select.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketEncryption.cc
+++ b/examples/SetBucketEncryption.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketLifecycle.cc
+++ b/examples/SetBucketLifecycle.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketNotification.cc
+++ b/examples/SetBucketNotification.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketPolicy.cc
+++ b/examples/SetBucketPolicy.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketReplication.cc
+++ b/examples/SetBucketReplication.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketTags.cc
+++ b/examples/SetBucketTags.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetBucketVersioning.cc
+++ b/examples/SetBucketVersioning.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetObjectLockConfig.cc
+++ b/examples/SetObjectLockConfig.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetObjectRetention.cc
+++ b/examples/SetObjectRetention.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/SetObjectTags.cc
+++ b/examples/SetObjectTags.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/StatObject.cc
+++ b/examples/StatObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/examples/UploadObject.cc
+++ b/examples/UploadObject.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include <miniocpp/client.h>
 
 int main() {
   // Create S3 base URL.

--- a/include/miniocpp/args.h
+++ b/include/miniocpp/args.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_ARGS_H
-#define _MINIO_S3_ARGS_H
+#ifndef MINIO_CPP_ARGS_H_INCLUDED
+#define MINIO_CPP_ARGS_H_INCLUDED
 
 #include <functional>
 #include <list>
@@ -30,6 +32,7 @@
 
 namespace minio {
 namespace s3 {
+
 struct BaseArgs {
   utils::Multimap extra_headers;
   utils::Multimap extra_query_params;
@@ -600,4 +603,5 @@ struct PostPolicy {
 };  // struct PostPolicy
 }  // namespace s3
 }  // namespace minio
-#endif  // #ifndef __MINIO_S3_ARGS_H
+
+#endif  // _MINIO_CPP_ARGS_H_INCLUDED

--- a/include/miniocpp/baseclient.h
+++ b/include/miniocpp/baseclient.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_BASE_CLIENT_H
-#define _MINIO_S3_BASE_CLIENT_H
+#ifndef MINIO_CPP_BASECLIENT_H_INCLUDED
+#define MINIO_CPP_BASECLIENT_H_INCLUDED
 
 #include <map>
 #include <string>
@@ -151,4 +153,5 @@ class BaseClient {
 };  // class BaseClient
 }  // namespace s3
 }  // namespace minio
-#endif  // #ifndef __MINIO_S3_BASE_CLIENT_H
+
+#endif  // MINIO_CPP_BASECLIENT_H_INCLUDED

--- a/include/miniocpp/client.h
+++ b/include/miniocpp/client.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_CLIENT_H
-#define _MINIO_S3_CLIENT_H
+#ifndef MINIO_CPP_CLIENT_H_INCLUDED
+#define MINIO_CPP_CLIENT_H_INCLUDED
 
 #include <list>
 #include <string>
@@ -28,6 +30,7 @@
 
 namespace minio {
 namespace s3 {
+
 class Client;
 
 class ListObjectsResult {
@@ -121,6 +124,8 @@ class Client : public BaseClient {
   UploadObjectResponse UploadObject(UploadObjectArgs args);
   RemoveObjectsResult RemoveObjects(RemoveObjectsArgs args);
 };  // class Client
+
 }  // namespace s3
 }  // namespace minio
-#endif  // #ifndef __MINIO_S3_CLIENT_H
+
+#endif  // MINIO_CPP_CLIENT_H_INCLUDED

--- a/include/miniocpp/config.h
+++ b/include/miniocpp/config.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #ifndef MINIO_CPP_CONFIG_H_INCLUDED
 #define MINIO_CPP_CONFIG_H_INCLUDED

--- a/include/miniocpp/credentials.h
+++ b/include/miniocpp/credentials.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_CREDS_CREDENTIALS_H
-#define _MINIO_CREDS_CREDENTIALS_H
+#ifndef MINIO_CPP_CREDENTIALS_H_INCLUDED
+#define MINIO_CPP_CREDENTIALS_H_INCLUDED
 
 #include <string>
 #include <type_traits>
@@ -24,6 +26,7 @@
 
 namespace minio {
 namespace creds {
+
 bool expired(const utils::UtcTime& expiration);
 
 /**
@@ -72,7 +75,8 @@ struct Credentials {
 
   static Credentials ParseXML(std::string_view data, const std::string& root);
 };  // class Credentials
+
 }  // namespace creds
 }  // namespace minio
 
-#endif  // #ifndef _MINIO_CREDS_CREDENTIALS_H
+#endif  // MINIO_CPP_CREDENTIALS_H_INCLUDED

--- a/include/miniocpp/error.h
+++ b/include/miniocpp/error.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_ERROR_H
-#define _MINIO_ERROR_H
+#ifndef MINIO_CPP_ERROR_H_INCLUDED
+#define MINIO_CPP_ERROR_H_INCLUDED
 
 #include <ostream>
 #include <string>
@@ -22,6 +24,7 @@
 
 namespace minio {
 namespace error {
+
 class Error {
  private:
   std::string msg_;
@@ -52,7 +55,8 @@ template <typename T_RESULT, typename... TA>
 inline T_RESULT make(TA&&... args) {
   return T_RESULT{Error(std::forward<TA>(args)...)};
 }
+
 }  // namespace error
 }  // namespace minio
 
-#endif  // #ifndef _MINIO_ERROR_H
+#endif  // MINIO_CPP_ERROR_H_INCLUDED

--- a/include/miniocpp/http.h
+++ b/include/miniocpp/http.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_HTTP_H
-#define _MINIO_HTTP_H
+#ifndef MINIO_CPP_HTTP_H_INCLUDED
+#define MINIO_CPP_HTTP_H_INCLUDED
 
 #include <curlpp/Easy.hpp>
 #include <curlpp/Multi.hpp>
@@ -29,6 +31,7 @@
 
 namespace minio {
 namespace http {
+
 enum class Method { kGet, kHead, kPost, kPut, kDelete };
 
 // MethodToString converts http Method enum to string.
@@ -182,6 +185,8 @@ struct Response {
   error::Error ReadStatusCode();
   error::Error ReadHeaders();
 };  // struct Response
+
 }  // namespace http
 }  // namespace minio
-#endif  // #ifndef _MINIO_HTTP_H
+
+#endif  // MINIO_CPP_HTTP_H_INCLUDED

--- a/include/miniocpp/providers.h
+++ b/include/miniocpp/providers.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_CREDS_PROVIDERS_H
-#define _MINIO_CREDS_PROVIDERS_H
+#ifndef MINIO_CPP_PROVIDERS_H_INCLUDED
+#define MINIO_CPP_PROVIDERS_H_INCLUDED
 
 #include <functional>
 #include <list>
@@ -31,6 +33,7 @@
 
 namespace minio {
 namespace creds {
+
 struct Jwt {
   std::string token;
   unsigned int expiry = 0;
@@ -246,7 +249,8 @@ struct CertificateIdentityProvider : public Provider {
 
   virtual Credentials Fetch() override;
 };  // struct CertificateIdentityProvider
+
 }  // namespace creds
 }  // namespace minio
 
-#endif  // #ifndef _MINIO_CREDS_PROVIDERS_H
+#endif  // MINIO_CPP_PROVIDERS_H_INCLUDED

--- a/include/miniocpp/request.h
+++ b/include/miniocpp/request.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_REQUEST_H
-#define _MINIO_REQUEST_H
+#ifndef MINIO_CPP_REQUEST_H_INCLUDED
+#define MINIO_CPP_REQUEST_H_INCLUDED
 
 #include <regex>
 #include <string>
@@ -26,6 +28,7 @@
 
 namespace minio {
 namespace s3 {
+
 const std::string AWS_S3_PREFIX =
     "^(((bucket\\.|accesspoint\\.)"
     "vpce(-(?!_)[a-z_\\d]+)+\\.s3\\.)|"
@@ -136,6 +139,8 @@ struct Request {
  private:
   void BuildHeaders(http::Url& url, creds::Provider* const provider);
 };  // struct Request
+
 }  // namespace s3
 }  // namespace minio
-#endif  // #ifndef __MINIO_REQUEST_H
+
+#endif  // MINIO_CPP_REQUEST_H_INCLUDED

--- a/include/miniocpp/response.h
+++ b/include/miniocpp/response.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_RESPONSE_H
-#define _MINIO_S3_RESPONSE_H
+#ifndef MINIO_CPP_RESPONSE_H_INCLUDED
+#define MINIO_CPP_RESPONSE_H_INCLUDED
 
 #include <list>
 #include <map>
@@ -27,6 +29,7 @@
 
 namespace minio {
 namespace s3 {
+
 struct Response {
   int status_code = 0;
   utils::Multimap headers;
@@ -565,7 +568,8 @@ struct GetPresignedPostFormDataResponse : public Response {
 
 #undef MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE
 #undef MINIO_S3_DERIVE_FROM_RESPONSE
+
 }  // namespace s3
 }  // namespace minio
 
-#endif  // #ifndef _MINIO_S3_RESPONSE_H
+#endif  // MINIO_CPP_RESPONSE_H_INCLUDED

--- a/include/miniocpp/select.h
+++ b/include/miniocpp/select.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_SELECT_H
-#define _MINIO_S3_SELECT_H
+#ifndef MINIO_CPP_SELECT_H_INCLUDED
+#define MINIO_CPP_SELECT_H_INCLUDED
 
 #include <map>
 #include <string>
@@ -67,4 +69,4 @@ class SelectHandler {
 }  // namespace s3
 }  // namespace minio
 
-#endif  // #ifndef _MINIO_S3_SELECT_H
+#endif  // MINIO_CPP_SELECT_H_INCLUDED

--- a/include/miniocpp/signer.h
+++ b/include/miniocpp/signer.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_SIGNER_H
-#define _MINIO_SIGNER_H
+#ifndef MINIO_CPP_SIGNER_H_INCLUDED
+#define MINIO_CPP_SIGNER_H_INCLUDED
 
 #include <string>
 
@@ -23,6 +25,7 @@
 
 namespace minio {
 namespace signer {
+
 std::string GetScope(const utils::UtcTime& time, const std::string& region,
                      const std::string& service_name);
 std::string GetCanonicalRequestHash(const std::string& method,
@@ -77,4 +80,5 @@ std::string PostPresignV4(const std::string& data,
                           const std::string& region);
 }  // namespace signer
 }  // namespace minio
-#endif  // #ifndef __MINIO_SIGNER_H
+
+#endif  // MINIO_CPP_SIGNER_H_INCLUDED

--- a/include/miniocpp/sse.h
+++ b/include/miniocpp/sse.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_SSE_H
-#define _MINIO_S3_SSE_H
+#ifndef MINIO_CPP_SSE_H_INCLUDED
+#define MINIO_CPP_SSE_H_INCLUDED
 
 #include <string>
 
@@ -63,4 +65,4 @@ class SseS3 : public Sse {
 }  // namespace s3
 }  // namespace minio
 
-#endif  // #ifndef __MINIO_S3_SSE_H
+#endif  // MINIO_CPP_SSE_H_INCLUDED

--- a/include/miniocpp/types.h
+++ b/include/miniocpp/types.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_S3_TYPES_H
-#define _MINIO_S3_TYPES_H
+#ifndef MINIO_CPP_TYPES_H_INCLUDED
+#define MINIO_CPP_TYPES_H_INCLUDED
 
 #include <exception>
 #include <functional>
@@ -31,6 +33,7 @@
 
 namespace minio {
 namespace s3 {
+
 enum class RetentionMode { kGovernance, kCompliance };
 
 // StringToRetentionMode converts string to retention mode enum.
@@ -763,6 +766,8 @@ struct ObjectLockConfig {
 
   error::Error Validate() const;
 };  // struct ObjectLockConfig
+
 }  // namespace s3
 }  // namespace minio
-#endif  // #ifndef __MINIO_S3_TYPES_H
+
+#endif  // MINIO_CPP_TYPES_H_INCLUDED

--- a/include/miniocpp/utils.h
+++ b/include/miniocpp/utils.h
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#ifndef _MINIO_UTILS_H
-#define _MINIO_UTILS_H
+#ifndef MINIO_CPP_UTILS_H_INCLUDED
+#define MINIO_CPP_UTILS_H_INCLUDED
 
 #ifndef _WIN32
 #include <pwd.h>
@@ -33,6 +35,7 @@
 
 namespace minio {
 namespace utils {
+
 inline constexpr unsigned int kMaxMultipartCount = 10000;      // 10000 parts
 inline constexpr uint64_t kMaxObjectSize = 5'497'558'138'880;  // 5TiB
 inline constexpr uint64_t kMaxPartSize = 5'368'709'120;        // 5GiB
@@ -223,7 +226,8 @@ struct CharBuffer : std::streambuf {
       off_type off, std::ios_base::seekdir dir,
       std::ios_base::openmode which = std::ios_base::in) override;
 };  // struct CharBuffer
+
 }  // namespace utils
 }  // namespace minio
 
-#endif  // #ifndef _MINIO_UTILS_H
+#endif  // MINIO_CPP_UTILS_H_INCLUDED

--- a/src/args.cc
+++ b/src/args.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "args.h"
+#include "miniocpp/args.h"
 
 #include <curlpp/cURLpp.hpp>
 #include <exception>
@@ -25,11 +27,11 @@
 #include <string>
 #include <type_traits>
 
-#include "error.h"
-#include "http.h"
-#include "signer.h"
-#include "types.h"
-#include "utils.h"
+#include "miniocpp/error.h"
+#include "miniocpp/http.h"
+#include "miniocpp/signer.h"
+#include "miniocpp/types.h"
+#include "miniocpp/utils.h"
 
 minio::error::Error minio::s3::BucketArgs::Validate() const {
   return utils::CheckBucketName(bucket);

--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "baseclient.h"
+#include "miniocpp/baseclient.h"
 
 #include <cstring>
 #include <exception>
@@ -28,18 +30,18 @@
 #include <string>
 #include <type_traits>
 
-#include "args.h"
-#include "config.h"
-#include "credentials.h"
-#include "error.h"
-#include "http.h"
-#include "providers.h"
-#include "request.h"
-#include "response.h"
-#include "select.h"
-#include "signer.h"
-#include "types.h"
-#include "utils.h"
+#include "miniocpp/args.h"
+#include "miniocpp/config.h"
+#include "miniocpp/credentials.h"
+#include "miniocpp/error.h"
+#include "miniocpp/http.h"
+#include "miniocpp/providers.h"
+#include "miniocpp/request.h"
+#include "miniocpp/response.h"
+#include "miniocpp/select.h"
+#include "miniocpp/signer.h"
+#include "miniocpp/types.h"
+#include "miniocpp/utils.h"
 
 minio::utils::Multimap minio::s3::GetCommonListObjectsQueryParams(
     const std::string& delimiter, const std::string& encoding_type,
@@ -361,12 +363,8 @@ minio::s3::BaseClient::CompleteMultipartUpload(
   std::stringstream ss;
   ss << "<CompleteMultipartUpload>";
   for (auto& part : args.parts) {
-    ss << "<Part>"
-       << "<PartNumber>" << part.number << "</PartNumber>"
-       << "<ETag>"
-       << "\"" << part.etag << "\""
-       << "</ETag>"
-       << "</Part>";
+    ss << "<Part>" << "<PartNumber>" << part.number << "</PartNumber>"
+       << "<ETag>" << "\"" << part.etag << "\"" << "</ETag>" << "</Part>";
   }
   ss << "</CompleteMultipartUpload>";
   std::string body = ss.str();
@@ -1348,9 +1346,8 @@ minio::s3::MakeBucketResponse minio::s3::BaseClient::MakeBucket(
   std::string body;
   if (region != "us-east-1") {
     std::stringstream ss;
-    ss << "<CreateBucketConfiguration>"
-       << "<LocationConstraint>" << region << "</LocationConstraint>"
-       << "</CreateBucketConfiguration>";
+    ss << "<CreateBucketConfiguration>" << "<LocationConstraint>" << region
+       << "</LocationConstraint>" << "</CreateBucketConfiguration>";
     body = ss.str();
     req.body = body;
   }
@@ -1671,10 +1668,8 @@ minio::s3::SetBucketTagsResponse minio::s3::BaseClient::SetBucketTags(
   if (!args.tags.empty()) {
     ss << "<TagSet>";
     for (auto& [key, value] : args.tags) {
-      ss << "<Tag>"
-         << "<Key>" << key << "</Key>"
-         << "<Value>" << value << "</Value>"
-         << "</Tag>";
+      ss << "<Tag>" << "<Key>" << key << "</Key>" << "<Value>" << value
+         << "</Value>" << "</Tag>";
     }
     ss << "</TagSet>";
   }
@@ -1788,10 +1783,9 @@ minio::s3::SetObjectRetentionResponse minio::s3::BaseClient::SetObjectRetention(
   }
 
   std::stringstream ss;
-  ss << "<Retention>"
-     << "<Mode>" << RetentionModeToString(args.retention_mode) << "</Mode>"
-     << "<RetainUntilDate>" << args.retain_until_date.ToISO8601UTC()
-     << "</RetainUntilDate>"
+  ss << "<Retention>" << "<Mode>" << RetentionModeToString(args.retention_mode)
+     << "</Mode>" << "<RetainUntilDate>"
+     << args.retain_until_date.ToISO8601UTC() << "</RetainUntilDate>"
      << "</Retention>";
 
   std::string body = ss.str();
@@ -1828,10 +1822,8 @@ minio::s3::SetObjectTagsResponse minio::s3::BaseClient::SetObjectTags(
   if (!args.tags.empty()) {
     ss << "<TagSet>";
     for (auto& [key, value] : args.tags) {
-      ss << "<Tag>"
-         << "<Key>" << key << "</Key>"
-         << "<Value>" << value << "</Value>"
-         << "</Tag>";
+      ss << "<Tag>" << "<Key>" << key << "</Key>" << "<Value>" << value
+         << "</Value>" << "</Tag>";
     }
     ss << "</TagSet>";
   }

--- a/src/client.cc
+++ b/src/client.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "client.h"
+#include "miniocpp/client.h"
 
 #include <curlpp/cURLpp.hpp>
 #include <filesystem>
@@ -24,16 +26,16 @@
 #include <system_error>
 #include <type_traits>
 
-#include "args.h"
-#include "baseclient.h"
-#include "error.h"
-#include "http.h"
-#include "providers.h"
-#include "request.h"
-#include "response.h"
-#include "sse.h"
-#include "types.h"
-#include "utils.h"
+#include "miniocpp/args.h"
+#include "miniocpp/baseclient.h"
+#include "miniocpp/error.h"
+#include "miniocpp/http.h"
+#include "miniocpp/providers.h"
+#include "miniocpp/request.h"
+#include "miniocpp/response.h"
+#include "miniocpp/sse.h"
+#include "miniocpp/types.h"
+#include "miniocpp/utils.h"
 
 minio::s3::ListObjectsResult::ListObjectsResult(error::Error err)
     : failed_(true) {

--- a/src/credentials.cc
+++ b/src/credentials.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "credentials.h"
+#include "miniocpp/credentials.h"
 
 #include <pugixml.hpp>
 #include <string>
 #include <type_traits>
 
-#include "error.h"
-#include "utils.h"
+#include "miniocpp/error.h"
+#include "miniocpp/utils.h"
 
 bool minio::creds::expired(const utils::UtcTime& expiration) {
   if (!expiration) return false;

--- a/src/http.cc
+++ b/src/http.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "miniocpp/http.h"
 
 #include <curl/curl.h>
 
@@ -32,6 +36,9 @@
 #include <string>
 #include <type_traits>
 
+#include "miniocpp/error.h"
+#include "miniocpp/utils.h"
+
 #ifdef _WIN32
 #include <WinSock2.h>
 #include <ws2def.h>    // NOTE needed for AF_INET6
@@ -40,10 +47,6 @@
 #else
 #include <arpa/inet.h>
 #endif
-
-#include "error.h"
-#include "http.h"
-#include "utils.h"
 
 std::string minio::http::Url::String() const {
   if (host.empty()) return {};

--- a/src/providers.cc
+++ b/src/providers.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,10 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 #ifdef _WIN32
 #define _WINSOCK_DEPRECATED_NO_WARNINGS
 #endif
+
+#include "miniocpp/providers.h"
 
 #include <INIReader.h>
 
@@ -26,6 +30,12 @@
 #include <string>
 #include <type_traits>
 
+#include "miniocpp/credentials.h"
+#include "miniocpp/error.h"
+#include "miniocpp/http.h"
+#include "miniocpp/signer.h"
+#include "miniocpp/utils.h"
+
 #ifdef _WIN32
 #include <WinSock2.h>
 #include <ws2def.h>
@@ -35,13 +45,6 @@
 #include <netdb.h>
 #include <sys/socket.h>
 #endif
-
-#include "credentials.h"
-#include "error.h"
-#include "http.h"
-#include "providers.h"
-#include "signer.h"
-#include "utils.h"
 
 minio::error::Error minio::creds::checkLoopbackHost(const std::string& host) {
   struct addrinfo hints = {};

--- a/src/request.cc
+++ b/src/request.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "request.h"
+#include "miniocpp/request.h"
 
 #include <exception>
 #include <iosfwd>
@@ -25,12 +27,12 @@
 #include <type_traits>
 #include <vector>
 
-#include "credentials.h"
-#include "error.h"
-#include "http.h"
-#include "providers.h"
-#include "signer.h"
-#include "utils.h"
+#include "miniocpp/credentials.h"
+#include "miniocpp/error.h"
+#include "miniocpp/http.h"
+#include "miniocpp/providers.h"
+#include "miniocpp/signer.h"
+#include "miniocpp/utils.h"
 
 #define EMPTY_SHA256 \
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/src/response.cc
+++ b/src/response.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "response.h"
+#include "miniocpp/response.h"
 
 #include <cstring>
 #include <curlpp/cURLpp.hpp>
@@ -23,9 +25,9 @@
 #include <string>
 #include <type_traits>
 
-#include "error.h"
-#include "types.h"
-#include "utils.h"
+#include "miniocpp/error.h"
+#include "miniocpp/types.h"
+#include "miniocpp/utils.h"
 
 minio::s3::Response::Response() {}
 

--- a/src/select.cc
+++ b/src/select.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "select.h"
+#include "miniocpp/select.h"
 
 #include <map>
 #include <pugixml.hpp>
 #include <string>
 
-#include "error.h"
-#include "http.h"
-#include "types.h"
-#include "utils.h"
+#include "miniocpp/error.h"
+#include "miniocpp/http.h"
+#include "miniocpp/types.h"
+#include "miniocpp/utils.h"
 
 void minio::s3::SelectHandler::Reset() {
   prelude_.clear();

--- a/src/signer.cc
+++ b/src/signer.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "signer.h"
+#include "miniocpp/signer.h"
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -23,8 +25,8 @@
 #include <string>
 #include <type_traits>
 
-#include "http.h"
-#include "utils.h"
+#include "miniocpp/http.h"
+#include "miniocpp/utils.h"
 
 const char* SIGN_V4_ALGORITHM = "AWS4-HMAC-SHA256";
 

--- a/src/sse.cc
+++ b/src/sse.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,12 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "sse.h"
+#include "miniocpp/sse.h"
 
 #include <string>
 
-#include "utils.h"
+#include "miniocpp/utils.h"
 
 minio::s3::Sse::Sse() {}
 

--- a/src/types.cc
+++ b/src/types.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
-#include "types.h"
+#include "miniocpp/types.h"
 
 #include <exception>
 #include <iosfwd>
@@ -23,7 +25,7 @@
 #include <sstream>
 #include <string>
 
-#include "error.h"
+#include "miniocpp/error.h"
 
 minio::s3::RetentionMode minio::s3::StringToRetentionMode(
     std::string_view str) noexcept {
@@ -340,10 +342,8 @@ std::string minio::s3::ReplicationConfig::ToXML() const {
 
   auto tag_xml = [](std::string key, std::string value) -> std::string {
     std::stringstream ss;
-    ss << "<Tag>"
-       << "<Key>" << key << "</Key>"
-       << "<Value>" << value << "</Value>"
-       << "</Tag>";
+    ss << "<Tag>" << "<Key>" << key << "</Key>" << "<Value>" << value
+       << "</Value>" << "</Tag>";
     return ss.str();
   };
 
@@ -373,8 +373,7 @@ std::string minio::s3::ReplicationConfig::ToXML() const {
       ss << "</EncryptionConfiguration>";
     }
     if (rule.destination.metrics) {
-      ss << "<Metrics>"
-         << "<EventThreshold>";
+      ss << "<Metrics>" << "<EventThreshold>";
       if (rule.destination.metrics.event_threshold_minutes > 0) {
         ss << minutes_xml(rule.destination.metrics.event_threshold_minutes);
       }
@@ -382,8 +381,7 @@ std::string minio::s3::ReplicationConfig::ToXML() const {
          << "</Metrics>";
     }
     if (rule.destination.replication_time) {
-      ss << "<ReplicationTime>"
-         << "<Time>";
+      ss << "<ReplicationTime>" << "<Time>";
       if (rule.destination.replication_time.time_minutes > 0) {
         ss << minutes_xml(rule.destination.replication_time.time_minutes);
       }
@@ -543,10 +541,8 @@ std::string minio::s3::LifecycleConfig::ToXML() const {
       }
       if (!rule.filter.and_operator.tags.empty()) {
         for (auto& [key, value] : rule.filter.and_operator.tags) {
-          ss << "<Tag>"
-             << "<Key>" << key << "</Key>"
-             << "<Value>" << value << "</Value>"
-             << "</Tag>";
+          ss << "<Tag>" << "<Key>" << key << "</Key>" << "<Value>" << value
+             << "</Value>" << "</Tag>";
         }
       }
       ss << "</And>";
@@ -555,10 +551,8 @@ std::string minio::s3::LifecycleConfig::ToXML() const {
       ss << "<Prefix>" << rule.filter.prefix << "</Prefix>";
     }
     if (rule.filter.tag) {
-      ss << "<Tag>"
-         << "<Key>" << rule.filter.tag.key << "</Key>"
-         << "<Value>" << rule.filter.tag.value << "</Value>"
-         << "</Tag>";
+      ss << "<Tag>" << "<Key>" << rule.filter.tag.key << "</Key>" << "<Value>"
+         << rule.filter.tag.value << "</Value>" << "</Tag>";
     }
     ss << "</Filter>";
 

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "miniocpp/utils.h"
+
+#include "miniocpp/error.h"
 
 #ifdef _WIN32
 #define _CRT_SECURE_NO_WARNINGS
@@ -52,9 +58,6 @@
 #include <string>
 #include <type_traits>
 #include <vector>
-
-#include "error.h"
-#include "utils.h"
 
 const std::string WEEK_DAYS[] = {"Sun", "Mon", "Tue", "Wed",
                                  "Thu", "Fri", "Sat"};
@@ -139,10 +142,8 @@ bool minio::utils::StringToBool(const std::string& str) {
 
 std::string minio::utils::Trim(std::string_view str, char ch) {
   std::size_t start, len;
-  for (start = 0; start < str.size() && str[start] == ch; start++)
-    ;
-  for (len = str.size() - start; len > 0 && str[start + len - 1] == ch; len--)
-    ;
+  for (start = 0; start < str.size() && str[start] == ch; start++);
+  for (len = str.size() - start; len > 0 && str[start + len - 1] == ch; len--);
   return std::string(str.substr(start, len));
 }
 

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1,5 +1,5 @@
 // MinIO C++ Library for Amazon S3 Compatible Cloud Storage
-// Copyright 2022 MinIO, Inc.
+// Copyright 2022-2024 MinIO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <miniocpp/args.h>
+#include <miniocpp/client.h>
+#include <miniocpp/http.h>
+#include <miniocpp/providers.h>
+#include <miniocpp/request.h>
+#include <miniocpp/response.h>
+#include <miniocpp/types.h>
+#include <miniocpp/utils.h>
 
 #include <array>
 #include <chrono>
@@ -30,15 +41,6 @@
 #include <string>
 #include <thread>
 #include <utility>
-
-#include "args.h"
-#include "client.h"
-#include "http.h"
-#include "providers.h"
-#include "request.h"
-#include "response.h"
-#include "types.h"
-#include "utils.h"
 
 thread_local static std::mt19937 rg{std::random_device{}()};
 


### PR DESCRIPTION
  * Use #include <minio-cpp/header.h> to include minio-cpp now
  * Header files have consistent guards that don't start with _
  * Added a SPDX license identifier to each source and header file