### PR TITLE
Include files cleanup and minor API changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+---
+BasedOnStyle: Google
+IndentWidth: 2
+---
+Language: Cpp
+DerivePointerAlignment: false
+PointerAlignment: Left
+---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(MINIO_CPP_SOURCES
   src/baseclient.cc
   src/client.cc
   src/credentials.cc
+  src/error.cc
   src/http.cc
   src/providers.cc
   src/request.cc

--- a/include/miniocpp/args.h
+++ b/include/miniocpp/args.h
@@ -30,8 +30,7 @@
 #include "types.h"
 #include "utils.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
 
 struct BaseArgs {
   utils::Multimap extra_headers;
@@ -63,9 +62,9 @@ struct ObjectArgs : public BucketArgs {
 struct ObjectWriteArgs : public ObjectArgs {
   utils::Multimap headers;
   utils::Multimap user_metadata;
-  Sse *sse = nullptr;
+  Sse* sse = nullptr;
   std::map<std::string, std::string> tags;
-  Retention *retention = nullptr;
+  Retention* retention = nullptr;
   bool legal_hold = false;
 
   ObjectWriteArgs() = default;
@@ -82,15 +81,15 @@ struct ObjectVersionArgs : public ObjectArgs {
 };  // struct ObjectVersionArgs
 
 struct ObjectReadArgs : public ObjectVersionArgs {
-  SseCustomerKey *ssec = nullptr;
+  SseCustomerKey* ssec = nullptr;
 
   ObjectReadArgs() = default;
   ~ObjectReadArgs() = default;
 };  // struct ObjectReadArgs
 
 struct ObjectConditionalReadArgs : public ObjectReadArgs {
-  size_t *offset = nullptr;
-  size_t *length = nullptr;
+  size_t* offset = nullptr;
+  size_t* length = nullptr;
   std::string match_etag;
   std::string not_match_etag;
   utils::UtcTime modified_since;
@@ -158,7 +157,7 @@ struct PutObjectApiArgs : public PutObjectBaseArgs {
   std::string_view data;
   utils::Multimap query_params;
   http::ProgressFunction progressfunc = nullptr;
-  void *progress_userdata = nullptr;
+  void* progress_userdata = nullptr;
 
   PutObjectApiArgs() = default;
   ~PutObjectApiArgs() = default;
@@ -169,7 +168,7 @@ struct UploadPartArgs : public ObjectWriteArgs {
   unsigned int part_number;
   std::string_view data;
   http::ProgressFunction progressfunc = nullptr;
-  void *progress_userdata = nullptr;
+  void* progress_userdata = nullptr;
 
   UploadPartArgs() = default;
   ~UploadPartArgs() = default;
@@ -196,7 +195,7 @@ struct DownloadObjectArgs : public ObjectReadArgs {
   std::string filename;
   bool overwrite;
   http::ProgressFunction progressfunc = nullptr;
-  void *progress_userdata = nullptr;
+  void* progress_userdata = nullptr;
 
   DownloadObjectArgs() = default;
   ~DownloadObjectArgs() = default;
@@ -206,9 +205,9 @@ struct DownloadObjectArgs : public ObjectReadArgs {
 
 struct GetObjectArgs : public ObjectConditionalReadArgs {
   http::DataFunction datafunc;
-  void *userdata = nullptr;
+  void* userdata = nullptr;
   http::ProgressFunction progressfunc = nullptr;
-  void *progress_userdata = nullptr;
+  void* progress_userdata = nullptr;
 
   GetObjectArgs() = default;
   ~GetObjectArgs() = default;
@@ -235,11 +234,11 @@ struct ListObjectsArgs : public BucketArgs {
   ListObjectsArgs() = default;
   ~ListObjectsArgs() = default;
 
-  ListObjectsArgs(const ListObjectsArgs &) = default;
-  ListObjectsArgs &operator=(const ListObjectsArgs &) = default;
+  ListObjectsArgs(const ListObjectsArgs&) = default;
+  ListObjectsArgs& operator=(const ListObjectsArgs&) = default;
 
-  ListObjectsArgs(ListObjectsArgs &&) = default;
-  ListObjectsArgs &operator=(ListObjectsArgs &&) = default;
+  ListObjectsArgs(ListObjectsArgs&&) = default;
+  ListObjectsArgs& operator=(ListObjectsArgs&&) = default;
 };  // struct ListObjectsArgs
 
 struct ListObjectsCommonArgs : public BucketArgs {
@@ -251,11 +250,11 @@ struct ListObjectsCommonArgs : public BucketArgs {
   ListObjectsCommonArgs() = default;
   ~ListObjectsCommonArgs() = default;
 
-  ListObjectsCommonArgs(const ListObjectsCommonArgs &) = default;
-  ListObjectsCommonArgs &operator=(const ListObjectsCommonArgs &) = default;
+  ListObjectsCommonArgs(const ListObjectsCommonArgs&) = default;
+  ListObjectsCommonArgs& operator=(const ListObjectsCommonArgs&) = default;
 
-  ListObjectsCommonArgs(ListObjectsCommonArgs &&) = default;
-  ListObjectsCommonArgs &operator=(ListObjectsCommonArgs &&) = default;
+  ListObjectsCommonArgs(ListObjectsCommonArgs&&) = default;
+  ListObjectsCommonArgs& operator=(ListObjectsCommonArgs&&) = default;
 };  // struct ListObjectsCommonArgs
 
 struct ListObjectsV1Args : public ListObjectsCommonArgs {
@@ -264,15 +263,15 @@ struct ListObjectsV1Args : public ListObjectsCommonArgs {
   ListObjectsV1Args();
 
   explicit ListObjectsV1Args(ListObjectsArgs args);
-  ListObjectsV1Args &operator=(ListObjectsArgs args);
+  ListObjectsV1Args& operator=(ListObjectsArgs args);
 
   ~ListObjectsV1Args() = default;
 
-  ListObjectsV1Args(const ListObjectsV1Args &) = default;
-  ListObjectsV1Args &operator=(const ListObjectsV1Args &) = default;
+  ListObjectsV1Args(const ListObjectsV1Args&) = default;
+  ListObjectsV1Args& operator=(const ListObjectsV1Args&) = default;
 
-  ListObjectsV1Args(ListObjectsV1Args &&) = default;
-  ListObjectsV1Args &operator=(ListObjectsV1Args &&) = default;
+  ListObjectsV1Args(ListObjectsV1Args&&) = default;
+  ListObjectsV1Args& operator=(ListObjectsV1Args&&) = default;
 };  // struct ListObjectsV1Args
 
 struct ListObjectsV2Args : public ListObjectsCommonArgs {
@@ -284,15 +283,15 @@ struct ListObjectsV2Args : public ListObjectsCommonArgs {
   ListObjectsV2Args();
 
   explicit ListObjectsV2Args(ListObjectsArgs args);
-  ListObjectsV2Args &operator=(ListObjectsArgs args);
+  ListObjectsV2Args& operator=(ListObjectsArgs args);
 
   ~ListObjectsV2Args() = default;
 
-  ListObjectsV2Args(const ListObjectsV2Args &) = default;
-  ListObjectsV2Args &operator=(const ListObjectsV2Args &) = default;
+  ListObjectsV2Args(const ListObjectsV2Args&) = default;
+  ListObjectsV2Args& operator=(const ListObjectsV2Args&) = default;
 
-  ListObjectsV2Args(ListObjectsV2Args &&) = default;
-  ListObjectsV2Args &operator=(ListObjectsV2Args &&) = default;
+  ListObjectsV2Args(ListObjectsV2Args&&) = default;
+  ListObjectsV2Args& operator=(ListObjectsV2Args&&) = default;
 };  // struct ListObjectsV2Args
 
 struct ListObjectVersionsArgs : public ListObjectsCommonArgs {
@@ -302,23 +301,23 @@ struct ListObjectVersionsArgs : public ListObjectsCommonArgs {
   ListObjectVersionsArgs();
 
   explicit ListObjectVersionsArgs(ListObjectsArgs args);
-  ListObjectVersionsArgs &operator=(ListObjectsArgs args);
+  ListObjectVersionsArgs& operator=(ListObjectsArgs args);
 
   ~ListObjectVersionsArgs() = default;
 
-  ListObjectVersionsArgs(const ListObjectVersionsArgs &) = default;
-  ListObjectVersionsArgs &operator=(const ListObjectVersionsArgs &) = default;
+  ListObjectVersionsArgs(const ListObjectVersionsArgs&) = default;
+  ListObjectVersionsArgs& operator=(const ListObjectVersionsArgs&) = default;
 
-  ListObjectVersionsArgs(ListObjectVersionsArgs &&) = default;
-  ListObjectVersionsArgs &operator=(ListObjectVersionsArgs &&) = default;
+  ListObjectVersionsArgs(ListObjectVersionsArgs&&) = default;
+  ListObjectVersionsArgs& operator=(ListObjectVersionsArgs&&) = default;
 };  // struct ListObjectVersionsArgs
 
 struct PutObjectArgs : public PutObjectBaseArgs {
-  std::istream &stream;
+  std::istream& stream;
   http::ProgressFunction progressfunc = nullptr;
-  void *progress_userdata = nullptr;
+  void* progress_userdata = nullptr;
 
-  PutObjectArgs(std::istream &stream, long object_size, long part_size);
+  PutObjectArgs(std::istream& stream, long object_size, long part_size);
   ~PutObjectArgs() = default;
 
   error::Error Validate();
@@ -328,8 +327,8 @@ using CopySource = ObjectConditionalReadArgs;
 
 struct CopyObjectArgs : public ObjectWriteArgs {
   CopySource source;
-  Directive *metadata_directive = nullptr;
-  Directive *tagging_directive = nullptr;
+  Directive* metadata_directive = nullptr;
+  Directive* tagging_directive = nullptr;
 
   CopyObjectArgs() = default;
   ~CopyObjectArgs() = default;
@@ -341,7 +340,7 @@ struct ComposeSource : public ObjectConditionalReadArgs {
   ComposeSource() = default;
   ~ComposeSource() = default;
 
-  error::Error BuildHeaders(size_t object_size, const std::string &etag);
+  error::Error BuildHeaders(size_t object_size, const std::string& etag);
   size_t ObjectSize() const;
   utils::Multimap Headers() const;
 
@@ -362,7 +361,7 @@ struct ComposeObjectArgs : public ObjectWriteArgs {
 struct UploadObjectArgs : public PutObjectBaseArgs {
   std::string filename;
   http::ProgressFunction progressfunc = nullptr;
-  void *progress_userdata = nullptr;
+  void* progress_userdata = nullptr;
 
   UploadObjectArgs() = default;
   ~UploadObjectArgs() = default;
@@ -379,7 +378,7 @@ struct RemoveObjectsApiArgs : public BucketArgs {
   ~RemoveObjectsApiArgs() = default;
 };  // struct RemoveObjectsApiArgs
 
-using DeleteObjectFunction = std::function<bool(DeleteObject &)>;
+using DeleteObjectFunction = std::function<bool(DeleteObject&)>;
 
 struct RemoveObjectsArgs : public BucketArgs {
   bool bypass_governance_mode = false;
@@ -392,10 +391,10 @@ struct RemoveObjectsArgs : public BucketArgs {
 };  // struct RemoveObjectsArgs
 
 struct SelectObjectContentArgs : public ObjectReadArgs {
-  SelectRequest &request;
+  SelectRequest& request;
   SelectResultFunction resultfunc = nullptr;
 
-  SelectObjectContentArgs(SelectRequest &req, SelectResultFunction func)
+  SelectObjectContentArgs(SelectRequest& req, SelectResultFunction func)
       : request(req), resultfunc(func) {}
 
   ~SelectObjectContentArgs() = default;
@@ -433,9 +432,9 @@ using DeleteBucketNotificationArgs = BucketArgs;
 using GetBucketNotificationArgs = BucketArgs;
 
 struct SetBucketNotificationArgs : public BucketArgs {
-  NotificationConfig &config;
+  NotificationConfig& config;
 
-  explicit SetBucketNotificationArgs(NotificationConfig &configvalue)
+  explicit SetBucketNotificationArgs(NotificationConfig& configvalue)
       : config(configvalue) {}
 
   ~SetBucketNotificationArgs() = default;
@@ -446,9 +445,9 @@ using DeleteBucketEncryptionArgs = BucketArgs;
 using GetBucketEncryptionArgs = BucketArgs;
 
 struct SetBucketEncryptionArgs : public BucketArgs {
-  SseConfig &config;
+  SseConfig& config;
 
-  explicit SetBucketEncryptionArgs(SseConfig &sseconfig) : config(sseconfig) {}
+  explicit SetBucketEncryptionArgs(SseConfig& sseconfig) : config(sseconfig) {}
 
   ~SetBucketEncryptionArgs() = default;
 
@@ -472,9 +471,9 @@ using DeleteBucketReplicationArgs = BucketArgs;
 using GetBucketReplicationArgs = BucketArgs;
 
 struct SetBucketReplicationArgs : public BucketArgs {
-  ReplicationConfig &config;
+  ReplicationConfig& config;
 
-  explicit SetBucketReplicationArgs(ReplicationConfig &value) : config(value) {}
+  explicit SetBucketReplicationArgs(ReplicationConfig& value) : config(value) {}
 
   ~SetBucketReplicationArgs() = default;
 };  // struct SetBucketReplication
@@ -484,9 +483,9 @@ using DeleteBucketLifecycleArgs = BucketArgs;
 using GetBucketLifecycleArgs = BucketArgs;
 
 struct SetBucketLifecycleArgs : public BucketArgs {
-  LifecycleConfig &config;
+  LifecycleConfig& config;
 
-  explicit SetBucketLifecycleArgs(LifecycleConfig &value) : config(value) {}
+  explicit SetBucketLifecycleArgs(LifecycleConfig& value) : config(value) {}
 
   ~SetBucketLifecycleArgs() = default;
 };  // struct SetBucketLifecycle
@@ -581,14 +580,14 @@ struct PostPolicy {
                                               size_t upper_limit);
   void RemoveContentLengthRangeCondition();
 
-  error::Error FormData(std::map<std::string, std::string> &data,
+  error::Error FormData(std::map<std::string, std::string>& data,
                         std::string access_key, std::string secret_key,
                         std::string session_token, std::string region);
 
  private:
-  static constexpr const char *eq_ = "eq";
-  static constexpr const char *starts_with_ = "starts-with";
-  static constexpr const char *algorithm_ = "AWS4-HMAC-SHA256";
+  static constexpr const char* eq_ = "eq";
+  static constexpr const char* starts_with_ = "starts-with";
+  static constexpr const char* algorithm_ = "AWS4-HMAC-SHA256";
 
   utils::UtcTime expiration_;
   std::map<std::string, std::map<std::string, std::string>> conditions_;
@@ -601,7 +600,7 @@ struct PostPolicy {
                                          std::string region);
   static bool isReservedElement(std::string element);
 };  // struct PostPolicy
-}  // namespace s3
-}  // namespace minio
+
+}  // namespace minio::s3
 
 #endif  // _MINIO_CPP_ARGS_H_INCLUDED

--- a/include/miniocpp/baseclient.h
+++ b/include/miniocpp/baseclient.h
@@ -31,8 +31,8 @@
 #include "response.h"
 #include "utils.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
+
 utils::Multimap GetCommonListObjectsQueryParams(
     const std::string& delimiter, const std::string& encoding_type,
     unsigned int max_keys, const std::string& prefix);
@@ -151,7 +151,7 @@ class BaseClient {
   UploadPartResponse UploadPart(UploadPartArgs args);
   UploadPartCopyResponse UploadPartCopy(UploadPartCopyArgs args);
 };  // class BaseClient
-}  // namespace s3
-}  // namespace minio
+
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_BASECLIENT_H_INCLUDED

--- a/include/miniocpp/client.h
+++ b/include/miniocpp/client.h
@@ -28,8 +28,7 @@
 #include "request.h"
 #include "response.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
 
 class Client;
 
@@ -125,7 +124,6 @@ class Client : public BaseClient {
   RemoveObjectsResult RemoveObjects(RemoveObjectsArgs args);
 };  // class Client
 
-}  // namespace s3
-}  // namespace minio
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_CLIENT_H_INCLUDED

--- a/include/miniocpp/credentials.h
+++ b/include/miniocpp/credentials.h
@@ -24,8 +24,7 @@
 #include "error.h"
 #include "utils.h"
 
-namespace minio {
-namespace creds {
+namespace minio::creds {
 
 bool expired(const utils::UtcTime& expiration);
 
@@ -76,7 +75,6 @@ struct Credentials {
   static Credentials ParseXML(std::string_view data, const std::string& root);
 };  // class Credentials
 
-}  // namespace creds
-}  // namespace minio
+}  // namespace minio::creds
 
 #endif  // MINIO_CPP_CREDENTIALS_H_INCLUDED

--- a/include/miniocpp/error.h
+++ b/include/miniocpp/error.h
@@ -22,8 +22,7 @@
 #include <string>
 #include <type_traits>
 
-namespace minio {
-namespace error {
+namespace minio::error {
 
 class Error {
  private:
@@ -31,17 +30,18 @@ class Error {
 
  public:
   Error() = default;
-  Error(std::string_view msg) : msg_(msg) {}
+
+  explicit Error(std::string msg) : msg_(std::move(msg)) {}
 
   Error(const Error&) = default;
-  Error& operator=(const Error&) = default;
-
   Error(Error&& v) = default;
+
+  Error& operator=(const Error&) = default;
   Error& operator=(Error&& v) = default;
 
   ~Error() = default;
 
-  std::string String() const { return msg_; }
+  const std::string& String() const { return msg_; }
   explicit operator bool() const { return !msg_.empty(); }
 
   friend std::ostream& operator<<(std::ostream& s, const Error& e) {
@@ -49,14 +49,13 @@ class Error {
   }
 };  // class Error
 
-const static Error SUCCESS;
+extern const Error SUCCESS;
 
 template <typename T_RESULT, typename... TA>
 inline T_RESULT make(TA&&... args) {
   return T_RESULT{Error(std::forward<TA>(args)...)};
 }
 
-}  // namespace error
-}  // namespace minio
+}  // namespace minio::error
 
 #endif  // MINIO_CPP_ERROR_H_INCLUDED

--- a/include/miniocpp/http.h
+++ b/include/miniocpp/http.h
@@ -29,32 +29,12 @@
 #include "error.h"
 #include "utils.h"
 
-namespace minio {
-namespace http {
+namespace minio::http {
 
 enum class Method { kGet, kHead, kPost, kPut, kDelete };
 
-// MethodToString converts http Method enum to string.
-constexpr const char* MethodToString(Method method) noexcept {
-  switch (method) {
-    case Method::kGet:
-      return "GET";
-    case Method::kHead:
-      return "HEAD";
-    case Method::kPost:
-      return "POST";
-    case Method::kPut:
-      return "PUT";
-    case Method::kDelete:
-      return "DELETE";
-    default: {
-      std::cerr << "ABORT: Unimplemented HTTP method. This should not happen."
-                << std::endl;
-      std::terminate();
-    }
-  }
-  return nullptr;
-}
+//! MethodToString converts http Method enum to string.
+const char* MethodToString(Method method) noexcept;
 
 /**
  * Url represents HTTP URL and it's components.
@@ -100,11 +80,10 @@ struct DataFunctionArgs {
   void* userdata = nullptr;
 
   DataFunctionArgs() = default;
-  explicit DataFunctionArgs(curlpp::Easy* handle, Response* response,
-                            void* userdata)
+  DataFunctionArgs(curlpp::Easy* handle, Response* response, void* userdata)
       : handle(handle), response(response), userdata(userdata) {}
-  explicit DataFunctionArgs(curlpp::Easy* handle, Response* response,
-                            std::string datachunk, void* userdata)
+  DataFunctionArgs(curlpp::Easy* handle, Response* response,
+                   std::string datachunk, void* userdata)
       : handle(handle),
         response(response),
         datachunk(std::move(datachunk)),
@@ -121,9 +100,6 @@ struct ProgressFunctionArgs {
   double download_speed = 0.0;
   double upload_speed = 0.0;
   void* userdata = nullptr;
-
-  ProgressFunctionArgs() = default;
-  ~ProgressFunctionArgs() = default;
 };  // struct ProgressFunctionArgs
 
 struct Request {
@@ -186,7 +162,6 @@ struct Response {
   error::Error ReadHeaders();
 };  // struct Response
 
-}  // namespace http
-}  // namespace minio
+}  // namespace minio::http
 
 #endif  // MINIO_CPP_HTTP_H_INCLUDED

--- a/include/miniocpp/providers.h
+++ b/include/miniocpp/providers.h
@@ -27,12 +27,16 @@
 #include "error.h"
 #include "http.h"
 
-#define DEFAULT_DURATION_SECONDS (60 * 60 * 24)  // 1 day.
-#define MIN_DURATION_SECONDS (60 * 15)           // 15 minutes.
-#define MAX_DURATION_SECONDS (60 * 60 * 24 * 7)  // 7 days.
+namespace minio::creds {
 
-namespace minio {
-namespace creds {
+// 1 day.
+static constexpr unsigned DEFAULT_DURATION_SECONDS = 60 * 60 * 24;
+
+// 15 minutes.
+static constexpr unsigned MIN_DURATION_SECONDS = 60 * 15;
+
+// 7 days.
+static constexpr unsigned MAX_DURATION_SECONDS = 60 * 60 * 24 * 7;
 
 struct Jwt {
   std::string token;
@@ -250,7 +254,6 @@ struct CertificateIdentityProvider : public Provider {
   virtual Credentials Fetch() override;
 };  // struct CertificateIdentityProvider
 
-}  // namespace creds
-}  // namespace minio
+}  // namespace minio::creds
 
 #endif  // MINIO_CPP_PROVIDERS_H_INCLUDED

--- a/include/miniocpp/request.h
+++ b/include/miniocpp/request.h
@@ -18,7 +18,6 @@
 #ifndef MINIO_CPP_REQUEST_H_INCLUDED
 #define MINIO_CPP_REQUEST_H_INCLUDED
 
-#include <regex>
 #include <string>
 
 #include "error.h"
@@ -26,36 +25,7 @@
 #include "providers.h"
 #include "utils.h"
 
-namespace minio {
-namespace s3 {
-
-const std::string AWS_S3_PREFIX =
-    "^(((bucket\\.|accesspoint\\.)"
-    "vpce(-(?!_)[a-z_\\d]+)+\\.s3\\.)|"
-    "((?!s3)(?!-)(?!_)[a-z_\\d-]{1,63}\\.)"
-    "s3-control(-(?!_)[a-z_\\d]+)*\\.|"
-    "(s3(-(?!_)[a-z_\\d]+)*\\.))";
-const std::regex HOSTNAME_REGEX(
-    "^((?!-)(?!_)[a-z_\\d-]{1,63}\\.)*"
-    "((?!_)(?!-)[a-z_\\d-]{1,63})$",
-    std::regex_constants::icase);
-const std::regex AWS_ENDPOINT_REGEX(".*\\.amazonaws\\.com(|\\.cn)$",
-                                    std::regex_constants::icase);
-const std::regex AWS_S3_ENDPOINT_REGEX(
-    AWS_S3_PREFIX + "((?!s3)(?!-)(?!_)[a-z_\\d-]{1,63}\\.)*" +
-        "amazonaws\\.com(|\\.cn)$",
-    std::regex_constants::icase);
-const std::regex AWS_ELB_ENDPOINT_REGEX(
-    "^(?!-)(?!_)[a-z_\\d-]{1,63}\\."
-    "(?!-)(?!_)[a-z_\\d-]{1,63}\\."
-    "elb\\.amazonaws\\.com$",
-    std::regex_constants::icase);
-const std::regex AWS_S3_PREFIX_REGEX(AWS_S3_PREFIX,
-                                     std::regex_constants::icase);
-const std::regex REGION_REGEX("^((?!_)(?!-)[a-z_\\d-]{1,63})$",
-                              std::regex_constants::icase);
-
-bool awsRegexMatch(std::string_view value, const std::regex& regex);
+namespace minio::s3 {
 
 error::Error getAwsInfo(const std::string& host, bool https,
                         std::string& region, std::string& aws_s3_prefix,
@@ -140,7 +110,6 @@ struct Request {
   void BuildHeaders(http::Url& url, creds::Provider* const provider);
 };  // struct Request
 
-}  // namespace s3
-}  // namespace minio
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_REQUEST_H_INCLUDED

--- a/include/miniocpp/response.h
+++ b/include/miniocpp/response.h
@@ -27,10 +27,10 @@
 #include "types.h"
 #include "utils.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
 
 struct Response {
+ public:
   int status_code = 0;
   utils::Multimap headers;
   std::string data;
@@ -43,6 +43,10 @@ struct Response {
   std::string bucket_name;
   std::string object_name;
 
+ private:
+  error::Error err_;
+
+ public:
   Response();
   explicit Response(error::Error err) : err_(std::move(err)) {}
 
@@ -63,9 +67,6 @@ struct Response {
 
   static Response ParseXML(std::string_view data, int status_code,
                            utils::Multimap headers);
-
- private:
-  error::Error err_;
 };  // struct Response
 
 #define MINIO_S3_DERIVE_FROM_RESPONSE(DerivedName)                       \
@@ -569,7 +570,6 @@ struct GetPresignedPostFormDataResponse : public Response {
 #undef MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE
 #undef MINIO_S3_DERIVE_FROM_RESPONSE
 
-}  // namespace s3
-}  // namespace minio
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_RESPONSE_H_INCLUDED

--- a/include/miniocpp/select.h
+++ b/include/miniocpp/select.h
@@ -26,8 +26,8 @@
 #include "http.h"
 #include "types.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
+
 class SelectHandler {
  private:
   SelectResultFunction result_func_ = nullptr;
@@ -41,7 +41,7 @@ class SelectHandler {
   std::string prelude_crc_;
   bool prelude_crc_read_ = false;
 
-  unsigned int total_length_ = 0;
+  size_t total_length_ = 0;
 
   std::string data_;
   bool data_read_ = false;
@@ -66,7 +66,7 @@ class SelectHandler {
 
   bool DataFunction(const http::DataFunctionArgs& args);
 };  // struct SelectHandler
-}  // namespace s3
-}  // namespace minio
+
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_SELECT_H_INCLUDED

--- a/include/miniocpp/signer.h
+++ b/include/miniocpp/signer.h
@@ -23,8 +23,7 @@
 #include "http.h"
 #include "utils.h"
 
-namespace minio {
-namespace signer {
+namespace minio::signer {
 
 std::string GetScope(const utils::UtcTime& time, const std::string& region,
                      const std::string& service_name);
@@ -78,7 +77,7 @@ std::string PostPresignV4(const std::string& data,
                           const std::string& secret_key,
                           const utils::UtcTime& date,
                           const std::string& region);
-}  // namespace signer
-}  // namespace minio
+
+}  // namespace minio::signer
 
 #endif  // MINIO_CPP_SIGNER_H_INCLUDED

--- a/include/miniocpp/sse.h
+++ b/include/miniocpp/sse.h
@@ -22,8 +22,8 @@
 
 #include "utils.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
+
 class Sse {
  protected:
   utils::Multimap headers_;
@@ -62,7 +62,7 @@ class SseS3 : public Sse {
 
   virtual bool TlsRequired() const override;
 };  // class SseS3
-}  // namespace s3
-}  // namespace minio
+
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_SSE_H_INCLUDED

--- a/include/miniocpp/types.h
+++ b/include/miniocpp/types.h
@@ -31,8 +31,7 @@
 #include "error.h"
 #include "utils.h"
 
-namespace minio {
-namespace s3 {
+namespace minio::s3 {
 
 enum class RetentionMode { kGovernance, kCompliance };
 
@@ -767,7 +766,6 @@ struct ObjectLockConfig {
   error::Error Validate() const;
 };  // struct ObjectLockConfig
 
-}  // namespace s3
-}  // namespace minio
+}  // namespace minio::s3
 
 #endif  // MINIO_CPP_TYPES_H_INCLUDED

--- a/include/miniocpp/utils.h
+++ b/include/miniocpp/utils.h
@@ -33,8 +33,7 @@
 
 #include "error.h"
 
-namespace minio {
-namespace utils {
+namespace minio::utils {
 
 inline constexpr unsigned int kMaxMultipartCount = 10000;      // 10000 parts
 inline constexpr uint64_t kMaxObjectSize = 5'497'558'138'880;  // 5TiB
@@ -227,7 +226,6 @@ struct CharBuffer : std::streambuf {
       std::ios_base::openmode which = std::ios_base::in) override;
 };  // struct CharBuffer
 
-}  // namespace utils
-}  // namespace minio
+}  // namespace minio::utils
 
 #endif  // MINIO_CPP_UTILS_H_INCLUDED

--- a/src/args.cc
+++ b/src/args.cc
@@ -33,11 +33,13 @@
 #include "miniocpp/types.h"
 #include "miniocpp/utils.h"
 
-minio::error::Error minio::s3::BucketArgs::Validate() const {
+namespace minio::s3 {
+
+error::Error BucketArgs::Validate() const {
   return utils::CheckBucketName(bucket);
 }
 
-minio::error::Error minio::s3::ObjectArgs::Validate() const {
+error::Error ObjectArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -48,7 +50,7 @@ minio::error::Error minio::s3::ObjectArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::utils::Multimap minio::s3::ObjectWriteArgs::Headers() const {
+utils::Multimap ObjectWriteArgs::Headers() const {
   utils::Multimap result_headers;
   result_headers.AddAll(extra_headers);
   result_headers.AddAll(headers);
@@ -82,7 +84,7 @@ minio::utils::Multimap minio::s3::ObjectWriteArgs::Headers() const {
   return result_headers;
 }
 
-minio::utils::Multimap minio::s3::ObjectConditionalReadArgs::Headers() const {
+utils::Multimap ObjectConditionalReadArgs::Headers() const {
   size_t* off = offset;
   size_t* len = length;
 
@@ -122,8 +124,7 @@ minio::utils::Multimap minio::s3::ObjectConditionalReadArgs::Headers() const {
   return result_headers;
 }
 
-minio::utils::Multimap minio::s3::ObjectConditionalReadArgs::CopyHeaders()
-    const {
+utils::Multimap ObjectConditionalReadArgs::CopyHeaders() const {
   utils::Multimap result_headers;
 
   std::string copy_source = curlpp::escape("/" + bucket + "/" + object);
@@ -154,11 +155,11 @@ minio::utils::Multimap minio::s3::ObjectConditionalReadArgs::CopyHeaders()
   return result_headers;
 }
 
-minio::error::Error minio::s3::MakeBucketArgs::Validate() const {
+error::Error MakeBucketArgs::Validate() const {
   return utils::CheckBucketName(bucket, true);
 }
 
-minio::error::Error minio::s3::AbortMultipartUploadArgs::Validate() const {
+error::Error AbortMultipartUploadArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -169,7 +170,7 @@ minio::error::Error minio::s3::AbortMultipartUploadArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::CompleteMultipartUploadArgs::Validate() const {
+error::Error CompleteMultipartUploadArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -180,21 +181,7 @@ minio::error::Error minio::s3::CompleteMultipartUploadArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::UploadPartArgs::Validate() const {
-  if (error::Error err = ObjectArgs::Validate()) {
-    return err;
-  }
-  if (!utils::CheckNonEmptyString(upload_id)) {
-    return error::Error("upload ID cannot be empty");
-  }
-  if (part_number < 1 || part_number > 10000) {
-    return error::Error("part number must be between 1 and 10000");
-  }
-
-  return error::SUCCESS;
-}
-
-minio::error::Error minio::s3::UploadPartCopyArgs::Validate() const {
+error::Error UploadPartArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -208,7 +195,21 @@ minio::error::Error minio::s3::UploadPartCopyArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::DownloadObjectArgs::Validate() const {
+error::Error UploadPartCopyArgs::Validate() const {
+  if (error::Error err = ObjectArgs::Validate()) {
+    return err;
+  }
+  if (!utils::CheckNonEmptyString(upload_id)) {
+    return error::Error("upload ID cannot be empty");
+  }
+  if (part_number < 1 || part_number > 10000) {
+    return error::Error("part number must be between 1 and 10000");
+  }
+
+  return error::SUCCESS;
+}
+
+error::Error DownloadObjectArgs::Validate() const {
   if (error::Error err = ObjectReadArgs::Validate()) {
     return err;
   }
@@ -223,7 +224,7 @@ minio::error::Error minio::s3::DownloadObjectArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::GetObjectArgs::Validate() const {
+error::Error GetObjectArgs::Validate() const {
   if (error::Error err = ObjectConditionalReadArgs::Validate()) {
     return err;
   }
@@ -234,9 +235,9 @@ minio::error::Error minio::s3::GetObjectArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::s3::ListObjectsV1Args::ListObjectsV1Args() {}
+ListObjectsV1Args::ListObjectsV1Args() {}
 
-minio::s3::ListObjectsV1Args::ListObjectsV1Args(ListObjectsArgs args) {
+ListObjectsV1Args::ListObjectsV1Args(ListObjectsArgs args) {
   this->extra_headers = args.extra_headers;
   this->extra_query_params = args.extra_query_params;
   this->bucket = args.bucket;
@@ -248,14 +249,13 @@ minio::s3::ListObjectsV1Args::ListObjectsV1Args(ListObjectsArgs args) {
   this->marker = args.marker;
 }
 
-minio::s3::ListObjectsV1Args& minio::s3::ListObjectsV1Args::operator=(
-    ListObjectsArgs args) {
+ListObjectsV1Args& ListObjectsV1Args::operator=(ListObjectsArgs args) {
   return this->operator=(ListObjectsV1Args(std::move(args)));
 }
 
-minio::s3::ListObjectsV2Args::ListObjectsV2Args() {}
+ListObjectsV2Args::ListObjectsV2Args() {}
 
-minio::s3::ListObjectsV2Args::ListObjectsV2Args(ListObjectsArgs args) {
+ListObjectsV2Args::ListObjectsV2Args(ListObjectsArgs args) {
   this->extra_headers = args.extra_headers;
   this->extra_query_params = args.extra_query_params;
   this->bucket = args.bucket;
@@ -270,15 +270,13 @@ minio::s3::ListObjectsV2Args::ListObjectsV2Args(ListObjectsArgs args) {
   this->include_user_metadata = args.include_user_metadata;
 }
 
-minio::s3::ListObjectsV2Args& minio::s3::ListObjectsV2Args::operator=(
-    ListObjectsArgs args) {
+ListObjectsV2Args& ListObjectsV2Args::operator=(ListObjectsArgs args) {
   return this->operator=(ListObjectsV2Args(std::move(args)));
 }
 
-minio::s3::ListObjectVersionsArgs::ListObjectVersionsArgs() {}
+ListObjectVersionsArgs::ListObjectVersionsArgs() {}
 
-minio::s3::ListObjectVersionsArgs::ListObjectVersionsArgs(
-    ListObjectsArgs args) {
+ListObjectVersionsArgs::ListObjectVersionsArgs(ListObjectsArgs args) {
   this->extra_headers = args.extra_headers;
   this->extra_query_params = args.extra_query_params;
   this->bucket = args.bucket;
@@ -291,24 +289,24 @@ minio::s3::ListObjectVersionsArgs::ListObjectVersionsArgs(
   this->version_id_marker = args.version_id_marker;
 }
 
-minio::s3::ListObjectVersionsArgs& minio::s3::ListObjectVersionsArgs::operator=(
+ListObjectVersionsArgs& ListObjectVersionsArgs::operator=(
     ListObjectsArgs args) {
   return this->operator=(ListObjectVersionsArgs(args));
 }
 
-minio::s3::PutObjectArgs::PutObjectArgs(std::istream& istream, long object_size,
-                                        long part_size)
+PutObjectArgs::PutObjectArgs(std::istream& istream, long object_size,
+                             long part_size)
     : stream(istream) {
   this->object_size = object_size;
   this->part_size = part_size;
 }
 
-minio::error::Error minio::s3::PutObjectArgs::Validate() {
+error::Error PutObjectArgs::Validate() {
   if (error::Error err = ObjectArgs::Validate()) return err;
   return utils::CalcPartInfo(object_size, part_size, part_count);
 }
 
-minio::error::Error minio::s3::CopyObjectArgs::Validate() const {
+error::Error CopyObjectArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -334,8 +332,8 @@ minio::error::Error minio::s3::CopyObjectArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::ComposeSource::BuildHeaders(
-    size_t object_size, const std::string& etag) {
+error::Error ComposeSource::BuildHeaders(size_t object_size,
+                                         const std::string& etag) {
   std::string msg = "source " + bucket + "/" + object;
   if (!version_id.empty()) {
     msg += "?versionId=" + version_id;
@@ -373,7 +371,7 @@ minio::error::Error minio::s3::ComposeSource::BuildHeaders(
   return error::SUCCESS;
 }
 
-size_t minio::s3::ComposeSource::ObjectSize() const {
+size_t ComposeSource::ObjectSize() const {
   if (object_size_ == -1) {
     std::cerr << "ABORT: ComposeSource::BuildHeaders() must be called prior to "
                  "this method invocation. This should not happen."
@@ -384,7 +382,7 @@ size_t minio::s3::ComposeSource::ObjectSize() const {
   return object_size_;
 }
 
-minio::utils::Multimap minio::s3::ComposeSource::Headers() const {
+utils::Multimap ComposeSource::Headers() const {
   if (!headers_) {
     std::cerr << "ABORT: ComposeSource::BuildHeaders() must be called prior to "
                  "this method invocation. This should not happen."
@@ -395,7 +393,7 @@ minio::utils::Multimap minio::s3::ComposeSource::Headers() const {
   return headers_;
 }
 
-minio::error::Error minio::s3::ComposeObjectArgs::Validate() const {
+error::Error ComposeObjectArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -413,7 +411,7 @@ minio::error::Error minio::s3::ComposeObjectArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::UploadObjectArgs::Validate() {
+error::Error UploadObjectArgs::Validate() {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -431,7 +429,7 @@ minio::error::Error minio::s3::UploadObjectArgs::Validate() {
   return utils::CalcPartInfo(object_size, part_size, part_count);
 }
 
-minio::error::Error minio::s3::RemoveObjectsArgs::Validate() const {
+error::Error RemoveObjectsArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -442,7 +440,7 @@ minio::error::Error minio::s3::RemoveObjectsArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SelectObjectContentArgs::Validate() const {
+error::Error SelectObjectContentArgs::Validate() const {
   if (error::Error err = ObjectReadArgs::Validate()) {
     return err;
   }
@@ -466,7 +464,7 @@ minio::error::Error minio::s3::SelectObjectContentArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::ListenBucketNotificationArgs::Validate() const {
+error::Error ListenBucketNotificationArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -476,7 +474,7 @@ minio::error::Error minio::s3::ListenBucketNotificationArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SetBucketPolicyArgs::Validate() const {
+error::Error SetBucketPolicyArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -487,7 +485,7 @@ minio::error::Error minio::s3::SetBucketPolicyArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SetBucketEncryptionArgs::Validate() const {
+error::Error SetBucketEncryptionArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -498,7 +496,7 @@ minio::error::Error minio::s3::SetBucketEncryptionArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SetBucketVersioningArgs::Validate() const {
+error::Error SetBucketVersioningArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -508,7 +506,7 @@ minio::error::Error minio::s3::SetBucketVersioningArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SetBucketTagsArgs::Validate() const {
+error::Error SetBucketTagsArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
@@ -530,14 +528,14 @@ minio::error::Error minio::s3::SetBucketTagsArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SetObjectLockConfigArgs::Validate() const {
+error::Error SetObjectLockConfigArgs::Validate() const {
   if (error::Error err = BucketArgs::Validate()) {
     return err;
   }
   return config.Validate();
 }
 
-minio::error::Error minio::s3::SetObjectTagsArgs::Validate() const {
+error::Error SetObjectTagsArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -559,7 +557,7 @@ minio::error::Error minio::s3::SetObjectTagsArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::SetObjectRetentionArgs::Validate() const {
+error::Error SetObjectRetentionArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -573,7 +571,7 @@ minio::error::Error minio::s3::SetObjectRetentionArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::GetPresignedObjectUrlArgs::Validate() const {
+error::Error GetPresignedObjectUrlArgs::Validate() const {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
@@ -588,8 +586,8 @@ minio::error::Error minio::s3::GetPresignedObjectUrlArgs::Validate() const {
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::PostPolicy::AddEqualsCondition(
-    std::string element, std::string value) {
+error::Error PostPolicy::AddEqualsCondition(std::string element,
+                                            std::string value) {
   if (element.empty()) {
     return error::Error("condition element cannot be empty");
   }
@@ -608,8 +606,7 @@ minio::error::Error minio::s3::PostPolicy::AddEqualsCondition(
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::PostPolicy::RemoveEqualsCondition(
-    std::string element) {
+error::Error PostPolicy::RemoveEqualsCondition(std::string element) {
   if (element.empty()) {
     return error::Error("condition element cannot be empty");
   }
@@ -617,8 +614,8 @@ minio::error::Error minio::s3::PostPolicy::RemoveEqualsCondition(
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::PostPolicy::AddStartsWithCondition(
-    std::string element, std::string value) {
+error::Error PostPolicy::AddStartsWithCondition(std::string element,
+                                                std::string value) {
   if (element.empty()) {
     return error::Error("condition element cannot be empty");
   }
@@ -638,8 +635,7 @@ minio::error::Error minio::s3::PostPolicy::AddStartsWithCondition(
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::PostPolicy::RemoveStartsWithCondition(
-    std::string element) {
+error::Error PostPolicy::RemoveStartsWithCondition(std::string element) {
   if (element.empty()) {
     return error::Error("condition element cannot be empty");
   }
@@ -647,8 +643,8 @@ minio::error::Error minio::s3::PostPolicy::RemoveStartsWithCondition(
   return error::SUCCESS;
 }
 
-minio::error::Error minio::s3::PostPolicy::AddContentLengthRangeCondition(
-    size_t lower_limit, size_t upper_limit) {
+error::Error PostPolicy::AddContentLengthRangeCondition(size_t lower_limit,
+                                                        size_t upper_limit) {
   if (lower_limit > upper_limit) {
     return error::Error("lower limit cannot be greater than upper limit");
   }
@@ -657,14 +653,16 @@ minio::error::Error minio::s3::PostPolicy::AddContentLengthRangeCondition(
   return error::SUCCESS;
 }
 
-void minio::s3::PostPolicy::RemoveContentLengthRangeCondition() {
+void PostPolicy::RemoveContentLengthRangeCondition() {
   lower_limit_ = Integer();
   upper_limit_ = Integer();
 }
 
-minio::error::Error minio::s3::PostPolicy::FormData(
-    std::map<std::string, std::string>& data, std::string access_key,
-    std::string secret_key, std::string session_token, std::string region) {
+error::Error PostPolicy::FormData(std::map<std::string, std::string>& data,
+                                  std::string access_key,
+                                  std::string secret_key,
+                                  std::string session_token,
+                                  std::string region) {
   if (region.empty()) {
     return error::Error("region cannot be empty");
   }
@@ -714,22 +712,24 @@ minio::error::Error minio::s3::PostPolicy::FormData(
   return error::SUCCESS;
 }
 
-std::string minio::s3::PostPolicy::trimDollar(std::string value) {
+std::string PostPolicy::trimDollar(std::string value) {
   if (value.front() == '$') {
     value.erase(0, 1);
   }
   return value;
 }
 
-std::string minio::s3::PostPolicy::getCredentialString(std::string access_key,
-                                                       utils::UtcTime date,
-                                                       std::string region) {
+std::string PostPolicy::getCredentialString(std::string access_key,
+                                            utils::UtcTime date,
+                                            std::string region) {
   return access_key + "/" + date.ToSignerDate() + "/" + region +
          "/s3/aws4_request";
 }
 
-bool minio::s3::PostPolicy::isReservedElement(std::string element) {
+bool PostPolicy::isReservedElement(std::string element) {
   return element == "bucket" || element == "x-amz-algorithm" ||
          element == "x-amz-credential" || element == "x-amz-date" ||
          element == "policy" || element == "x-amz-signature";
 }
+
+}  // namespace minio::s3

--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -43,7 +43,9 @@
 #include "miniocpp/types.h"
 #include "miniocpp/utils.h"
 
-minio::utils::Multimap minio::s3::GetCommonListObjectsQueryParams(
+namespace minio::s3 {
+
+utils::Multimap GetCommonListObjectsQueryParams(
     const std::string& delimiter, const std::string& encoding_type,
     unsigned int max_keys, const std::string& prefix) {
   utils::Multimap query_params;
@@ -54,7 +56,7 @@ minio::utils::Multimap minio::s3::GetCommonListObjectsQueryParams(
   return query_params;
 }
 
-minio::s3::BaseClient::BaseClient(BaseUrl base_url, creds::Provider* provider)
+BaseClient::BaseClient(BaseUrl base_url, creds::Provider* provider)
     : base_url_(std::move(base_url)), provider_(provider) {
   if (!base_url_) {
     std::cerr << "valid base url must be provided; " << base_url_.Error()
@@ -63,8 +65,8 @@ minio::s3::BaseClient::BaseClient(BaseUrl base_url, creds::Provider* provider)
   }
 }
 
-minio::error::Error minio::s3::BaseClient::SetAppInfo(
-    std::string_view app_name, std::string_view app_version) {
+error::Error BaseClient::SetAppInfo(std::string_view app_name,
+                                    std::string_view app_version) {
   if (app_name.empty() || app_version.empty()) {
     return error::Error("Application name/version cannot be empty");
   }
@@ -74,10 +76,11 @@ minio::error::Error minio::s3::BaseClient::SetAppInfo(
   return error::SUCCESS;
 }
 
-void minio::s3::BaseClient::HandleRedirectResponse(
-    std::string& code, std::string& message, int status_code,
-    http::Method method, const utils::Multimap& headers,
-    const std::string& bucket_name, bool retry) {
+void BaseClient::HandleRedirectResponse(std::string& code, std::string& message,
+                                        int status_code, http::Method method,
+                                        const utils::Multimap& headers,
+                                        const std::string& bucket_name,
+                                        bool retry) {
   switch (status_code) {
     case 301:
       code = "PermanentRedirect";
@@ -110,9 +113,11 @@ void minio::s3::BaseClient::HandleRedirectResponse(
   }
 }
 
-minio::s3::Response minio::s3::BaseClient::GetErrorResponse(
-    http::Response resp, std::string_view resource, http::Method method,
-    const std::string& bucket_name, const std::string& object_name) {
+Response BaseClient::GetErrorResponse(http::Response resp,
+                                      std::string_view resource,
+                                      http::Method method,
+                                      const std::string& bucket_name,
+                                      const std::string& object_name) {
   if (!resp.error.empty()) {
     return error::make<Response>(resp.error);
   }
@@ -199,7 +204,7 @@ minio::s3::Response minio::s3::BaseClient::GetErrorResponse(
   return response;
 }
 
-minio::s3::Response minio::s3::BaseClient::execute(Request& req) {
+Response BaseClient::execute(Request& req) {
   req.user_agent = user_agent_;
   req.ignore_cert_check = ignore_cert_check_;
   if (!ssl_cert_file_.empty()) req.ssl_cert_file = ssl_cert_file_;
@@ -223,7 +228,7 @@ minio::s3::Response minio::s3::BaseClient::execute(Request& req) {
   return resp;
 }
 
-minio::s3::Response minio::s3::BaseClient::Execute(Request& req) {
+Response BaseClient::Execute(Request& req) {
   Response resp = execute(req);
   if (resp || resp.code != "RetryHead") return resp;
 
@@ -241,8 +246,8 @@ minio::s3::Response minio::s3::BaseClient::Execute(Request& req) {
   return resp;
 }
 
-minio::s3::GetRegionResponse minio::s3::BaseClient::GetRegion(
-    const std::string& bucket_name, const std::string& region) {
+GetRegionResponse BaseClient::GetRegion(const std::string& bucket_name,
+                                        const std::string& region) {
   std::string base_region = base_url_.region;
   if (!region.empty()) {
     if (!base_region.empty() && base_region != region) {
@@ -294,8 +299,8 @@ minio::s3::GetRegionResponse minio::s3::BaseClient::GetRegion(
   return GetRegionResponse(value);
 }
 
-minio::s3::AbortMultipartUploadResponse
-minio::s3::BaseClient::AbortMultipartUpload(AbortMultipartUploadArgs args) {
+AbortMultipartUploadResponse BaseClient::AbortMultipartUpload(
+    AbortMultipartUploadArgs args) {
   if (error::Error err = args.Validate()) {
     return AbortMultipartUploadResponse(err);
   }
@@ -316,8 +321,7 @@ minio::s3::BaseClient::AbortMultipartUpload(AbortMultipartUploadArgs args) {
   return AbortMultipartUploadResponse(Execute(req));
 }
 
-minio::s3::BucketExistsResponse minio::s3::BaseClient::BucketExists(
-    BucketExistsArgs args) {
+BucketExistsResponse BaseClient::BucketExists(BucketExistsArgs args) {
   if (error::Error err = args.Validate()) {
     return BucketExistsResponse(err);
   }
@@ -340,8 +344,7 @@ minio::s3::BucketExistsResponse minio::s3::BaseClient::BucketExists(
   }
 }
 
-minio::s3::CompleteMultipartUploadResponse
-minio::s3::BaseClient::CompleteMultipartUpload(
+CompleteMultipartUploadResponse BaseClient::CompleteMultipartUpload(
     CompleteMultipartUploadArgs args) {
   if (error::Error err = args.Validate()) {
     return CompleteMultipartUploadResponse(err);
@@ -383,8 +386,8 @@ minio::s3::BaseClient::CompleteMultipartUpload(
       response.data, response.headers.GetFront("x-amz-version-id"));
 }
 
-minio::s3::CreateMultipartUploadResponse
-minio::s3::BaseClient::CreateMultipartUpload(CreateMultipartUploadArgs args) {
+CreateMultipartUploadResponse BaseClient::CreateMultipartUpload(
+    CreateMultipartUploadArgs args) {
   if (error::Error err = args.Validate()) {
     return CreateMultipartUploadResponse(err);
   }
@@ -421,8 +424,8 @@ minio::s3::BaseClient::CreateMultipartUpload(CreateMultipartUploadArgs args) {
   }
 }
 
-minio::s3::DeleteBucketEncryptionResponse
-minio::s3::BaseClient::DeleteBucketEncryption(DeleteBucketEncryptionArgs args) {
+DeleteBucketEncryptionResponse BaseClient::DeleteBucketEncryption(
+    DeleteBucketEncryptionArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteBucketEncryptionResponse(err);
   }
@@ -449,8 +452,8 @@ minio::s3::BaseClient::DeleteBucketEncryption(DeleteBucketEncryptionArgs args) {
   return DeleteBucketEncryptionResponse();
 }
 
-minio::s3::DisableObjectLegalHoldResponse
-minio::s3::BaseClient::DisableObjectLegalHold(DisableObjectLegalHoldArgs args) {
+DisableObjectLegalHoldResponse BaseClient::DisableObjectLegalHold(
+    DisableObjectLegalHoldArgs args) {
   if (error::Error err = args.Validate()) {
     return DisableObjectLegalHoldResponse(err);
   }
@@ -477,8 +480,8 @@ minio::s3::BaseClient::DisableObjectLegalHold(DisableObjectLegalHoldArgs args) {
   return DisableObjectLegalHoldResponse(Execute(req));
 }
 
-minio::s3::DeleteBucketLifecycleResponse
-minio::s3::BaseClient::DeleteBucketLifecycle(DeleteBucketLifecycleArgs args) {
+DeleteBucketLifecycleResponse BaseClient::DeleteBucketLifecycle(
+    DeleteBucketLifecycleArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteBucketLifecycleResponse(err);
   }
@@ -498,8 +501,7 @@ minio::s3::BaseClient::DeleteBucketLifecycle(DeleteBucketLifecycleArgs args) {
   return DeleteBucketLifecycleResponse(Execute(req));
 }
 
-minio::s3::DeleteBucketNotificationResponse
-minio::s3::BaseClient::DeleteBucketNotification(
+DeleteBucketNotificationResponse BaseClient::DeleteBucketNotification(
     DeleteBucketNotificationArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteBucketNotificationResponse(err);
@@ -515,7 +517,7 @@ minio::s3::BaseClient::DeleteBucketNotification(
   return DeleteBucketNotificationResponse(SetBucketNotification(sbnargs));
 }
 
-minio::s3::DeleteBucketPolicyResponse minio::s3::BaseClient::DeleteBucketPolicy(
+DeleteBucketPolicyResponse BaseClient::DeleteBucketPolicy(
     DeleteBucketPolicyArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteBucketPolicyResponse(err);
@@ -536,8 +538,7 @@ minio::s3::DeleteBucketPolicyResponse minio::s3::BaseClient::DeleteBucketPolicy(
   return DeleteBucketPolicyResponse(Execute(req));
 }
 
-minio::s3::DeleteBucketReplicationResponse
-minio::s3::BaseClient::DeleteBucketReplication(
+DeleteBucketReplicationResponse BaseClient::DeleteBucketReplication(
     DeleteBucketReplicationArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteBucketReplicationResponse(err);
@@ -565,7 +566,7 @@ minio::s3::BaseClient::DeleteBucketReplication(
   return DeleteBucketReplicationResponse();
 }
 
-minio::s3::DeleteBucketTagsResponse minio::s3::BaseClient::DeleteBucketTags(
+DeleteBucketTagsResponse BaseClient::DeleteBucketTags(
     DeleteBucketTagsArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteBucketTagsResponse(err);
@@ -586,8 +587,8 @@ minio::s3::DeleteBucketTagsResponse minio::s3::BaseClient::DeleteBucketTags(
   return DeleteBucketTagsResponse(Execute(req));
 }
 
-minio::s3::DeleteObjectLockConfigResponse
-minio::s3::BaseClient::DeleteObjectLockConfig(DeleteObjectLockConfigArgs args) {
+DeleteObjectLockConfigResponse BaseClient::DeleteObjectLockConfig(
+    DeleteObjectLockConfigArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteObjectLockConfigResponse(err);
   }
@@ -607,7 +608,7 @@ minio::s3::BaseClient::DeleteObjectLockConfig(DeleteObjectLockConfigArgs args) {
   return DeleteObjectLockConfigResponse(Execute(req));
 }
 
-minio::s3::DeleteObjectTagsResponse minio::s3::BaseClient::DeleteObjectTags(
+DeleteObjectTagsResponse BaseClient::DeleteObjectTags(
     DeleteObjectTagsArgs args) {
   if (error::Error err = args.Validate()) {
     return DeleteObjectTagsResponse(err);
@@ -632,8 +633,8 @@ minio::s3::DeleteObjectTagsResponse minio::s3::BaseClient::DeleteObjectTags(
   return DeleteObjectTagsResponse(Execute(req));
 }
 
-minio::s3::EnableObjectLegalHoldResponse
-minio::s3::BaseClient::EnableObjectLegalHold(EnableObjectLegalHoldArgs args) {
+EnableObjectLegalHoldResponse BaseClient::EnableObjectLegalHold(
+    EnableObjectLegalHoldArgs args) {
   if (error::Error err = args.Validate()) {
     return EnableObjectLegalHoldResponse(err);
   }
@@ -661,8 +662,8 @@ minio::s3::BaseClient::EnableObjectLegalHold(EnableObjectLegalHoldArgs args) {
   return EnableObjectLegalHoldResponse(Execute(req));
 }
 
-minio::s3::GetBucketEncryptionResponse
-minio::s3::BaseClient::GetBucketEncryption(GetBucketEncryptionArgs args) {
+GetBucketEncryptionResponse BaseClient::GetBucketEncryption(
+    GetBucketEncryptionArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketEncryptionResponse(err);
   }
@@ -686,7 +687,7 @@ minio::s3::BaseClient::GetBucketEncryption(GetBucketEncryptionArgs args) {
   return GetBucketEncryptionResponse(resp);
 }
 
-minio::s3::GetBucketLifecycleResponse minio::s3::BaseClient::GetBucketLifecycle(
+GetBucketLifecycleResponse BaseClient::GetBucketLifecycle(
     GetBucketLifecycleArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketLifecycleResponse(err);
@@ -716,8 +717,8 @@ minio::s3::GetBucketLifecycleResponse minio::s3::BaseClient::GetBucketLifecycle(
   return GetBucketLifecycleResponse::ParseXML(resp.data);
 }
 
-minio::s3::GetBucketNotificationResponse
-minio::s3::BaseClient::GetBucketNotification(GetBucketNotificationArgs args) {
+GetBucketNotificationResponse BaseClient::GetBucketNotification(
+    GetBucketNotificationArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketNotificationResponse(err);
   }
@@ -741,8 +742,7 @@ minio::s3::BaseClient::GetBucketNotification(GetBucketNotificationArgs args) {
   return GetBucketNotificationResponse(resp);
 }
 
-minio::s3::GetBucketPolicyResponse minio::s3::BaseClient::GetBucketPolicy(
-    GetBucketPolicyArgs args) {
+GetBucketPolicyResponse BaseClient::GetBucketPolicy(GetBucketPolicyArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketPolicyResponse(err);
   }
@@ -766,8 +766,8 @@ minio::s3::GetBucketPolicyResponse minio::s3::BaseClient::GetBucketPolicy(
   return GetBucketPolicyResponse(resp);
 }
 
-minio::s3::GetBucketReplicationResponse
-minio::s3::BaseClient::GetBucketReplication(GetBucketReplicationArgs args) {
+GetBucketReplicationResponse BaseClient::GetBucketReplication(
+    GetBucketReplicationArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketReplicationResponse(err);
   }
@@ -791,8 +791,7 @@ minio::s3::BaseClient::GetBucketReplication(GetBucketReplicationArgs args) {
   return GetBucketReplicationResponse(resp);
 }
 
-minio::s3::GetBucketTagsResponse minio::s3::BaseClient::GetBucketTags(
-    GetBucketTagsArgs args) {
+GetBucketTagsResponse BaseClient::GetBucketTags(GetBucketTagsArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketTagsResponse(err);
   }
@@ -816,8 +815,8 @@ minio::s3::GetBucketTagsResponse minio::s3::BaseClient::GetBucketTags(
   return GetBucketTagsResponse(resp);
 }
 
-minio::s3::GetBucketVersioningResponse
-minio::s3::BaseClient::GetBucketVersioning(GetBucketVersioningArgs args) {
+GetBucketVersioningResponse BaseClient::GetBucketVersioning(
+    GetBucketVersioningArgs args) {
   if (error::Error err = args.Validate()) {
     return GetBucketVersioningResponse(err);
   }
@@ -862,8 +861,7 @@ minio::s3::BaseClient::GetBucketVersioning(GetBucketVersioningArgs args) {
   return GetBucketVersioningResponse(response);
 }
 
-minio::s3::GetObjectResponse minio::s3::BaseClient::GetObject(
-    GetObjectArgs args) {
+GetObjectResponse BaseClient::GetObject(GetObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return GetObjectResponse(err);
   }
@@ -896,8 +894,8 @@ minio::s3::GetObjectResponse minio::s3::BaseClient::GetObject(
   return GetObjectResponse(Execute(req));
 }
 
-minio::s3::GetObjectLockConfigResponse
-minio::s3::BaseClient::GetObjectLockConfig(GetObjectLockConfigArgs args) {
+GetObjectLockConfigResponse BaseClient::GetObjectLockConfig(
+    GetObjectLockConfigArgs args) {
   if (error::Error err = args.Validate()) {
     return GetObjectLockConfigResponse(err);
   }
@@ -947,7 +945,7 @@ minio::s3::BaseClient::GetObjectLockConfig(GetObjectLockConfigArgs args) {
   return GetObjectLockConfigResponse(config);
 }
 
-minio::s3::GetObjectRetentionResponse minio::s3::BaseClient::GetObjectRetention(
+GetObjectRetentionResponse BaseClient::GetObjectRetention(
     GetObjectRetentionArgs args) {
   if (error::Error err = args.Validate()) {
     return GetObjectRetentionResponse(err);
@@ -995,8 +993,7 @@ minio::s3::GetObjectRetentionResponse minio::s3::BaseClient::GetObjectRetention(
   return GetObjectRetentionResponse(response);
 }
 
-minio::s3::GetObjectTagsResponse minio::s3::BaseClient::GetObjectTags(
-    GetObjectTagsArgs args) {
+GetObjectTagsResponse BaseClient::GetObjectTags(GetObjectTagsArgs args) {
   if (error::Error err = args.Validate()) {
     return GetObjectTagsResponse(err);
   }
@@ -1024,8 +1021,8 @@ minio::s3::GetObjectTagsResponse minio::s3::BaseClient::GetObjectTags(
   return GetObjectTagsResponse(resp);
 }
 
-minio::s3::GetPresignedObjectUrlResponse
-minio::s3::BaseClient::GetPresignedObjectUrl(GetPresignedObjectUrlArgs args) {
+GetPresignedObjectUrlResponse BaseClient::GetPresignedObjectUrl(
+    GetPresignedObjectUrlArgs args) {
   if (error::Error err = args.Validate()) {
     return GetPresignedObjectUrlResponse(err);
   }
@@ -1068,8 +1065,8 @@ minio::s3::BaseClient::GetPresignedObjectUrl(GetPresignedObjectUrlArgs args) {
   return GetPresignedObjectUrlResponse(url.String());
 }
 
-minio::s3::GetPresignedPostFormDataResponse
-minio::s3::BaseClient::GetPresignedPostFormData(PostPolicy policy) {
+GetPresignedPostFormDataResponse BaseClient::GetPresignedPostFormData(
+    PostPolicy policy) {
   if (!policy) {
     return error::make<GetPresignedPostFormDataResponse>(
         "valid policy must be provided");
@@ -1097,8 +1094,7 @@ minio::s3::BaseClient::GetPresignedPostFormData(PostPolicy policy) {
   return GetPresignedPostFormDataResponse(data);
 }
 
-minio::s3::IsObjectLegalHoldEnabledResponse
-minio::s3::BaseClient::IsObjectLegalHoldEnabled(
+IsObjectLegalHoldEnabledResponse BaseClient::IsObjectLegalHoldEnabled(
     IsObjectLegalHoldEnabledArgs args) {
   if (error::Error err = args.Validate()) {
     return IsObjectLegalHoldEnabledResponse(err);
@@ -1138,8 +1134,7 @@ minio::s3::BaseClient::IsObjectLegalHoldEnabled(
   return IsObjectLegalHoldEnabledResponse(value == "ON");
 }
 
-minio::s3::ListBucketsResponse minio::s3::BaseClient::ListBuckets(
-    ListBucketsArgs args) {
+ListBucketsResponse BaseClient::ListBuckets(ListBucketsArgs args) {
   Request req(http::Method::kGet, base_url_.region, base_url_,
               args.extra_headers, args.extra_query_params);
   Response resp = Execute(req);
@@ -1149,12 +1144,11 @@ minio::s3::ListBucketsResponse minio::s3::BaseClient::ListBuckets(
   return ListBucketsResponse::ParseXML(resp.data);
 }
 
-minio::s3::ListBucketsResponse minio::s3::BaseClient::ListBuckets() {
+ListBucketsResponse BaseClient::ListBuckets() {
   return ListBuckets(ListBucketsArgs());
 }
 
-minio::s3::ListenBucketNotificationResponse
-minio::s3::BaseClient::ListenBucketNotification(
+ListenBucketNotificationResponse BaseClient::ListenBucketNotification(
     ListenBucketNotificationArgs args) {
   if (error::Error err = args.Validate()) {
     return ListenBucketNotificationResponse(err);
@@ -1202,7 +1196,7 @@ minio::s3::BaseClient::ListenBucketNotification(
       if (!json.contains("Records")) continue;
 
       nlohmann::json j_records = json["Records"];
-      std::list<minio::s3::NotificationRecord> records;
+      std::list<NotificationRecord> records;
       for (auto& j_record : j_records) {
         records.push_back(NotificationRecord::ParseJSON(j_record));
       }
@@ -1218,8 +1212,7 @@ minio::s3::BaseClient::ListenBucketNotification(
   return ListenBucketNotificationResponse(Execute(req));
 }
 
-minio::s3::ListObjectsResponse minio::s3::BaseClient::ListObjectsV1(
-    ListObjectsV1Args args) {
+ListObjectsResponse BaseClient::ListObjectsV1(ListObjectsV1Args args) {
   if (error::Error err = args.Validate()) {
     return ListObjectsResponse(err);
   }
@@ -1246,8 +1239,7 @@ minio::s3::ListObjectsResponse minio::s3::BaseClient::ListObjectsV1(
   return ListObjectsResponse::ParseXML(resp.data, false);
 }
 
-minio::s3::ListObjectsResponse minio::s3::BaseClient::ListObjectsV2(
-    ListObjectsV2Args args) {
+ListObjectsResponse BaseClient::ListObjectsV2(ListObjectsV2Args args) {
   if (error::Error err = args.Validate()) {
     return ListObjectsResponse(err);
   }
@@ -1284,7 +1276,7 @@ minio::s3::ListObjectsResponse minio::s3::BaseClient::ListObjectsV2(
   return ListObjectsResponse::ParseXML(resp.data, false);
 }
 
-minio::s3::ListObjectsResponse minio::s3::BaseClient::ListObjectVersions(
+ListObjectsResponse BaseClient::ListObjectVersions(
     ListObjectVersionsArgs args) {
   if (error::Error err = args.Validate()) {
     return ListObjectsResponse(err);
@@ -1317,8 +1309,7 @@ minio::s3::ListObjectsResponse minio::s3::BaseClient::ListObjectVersions(
   return ListObjectsResponse::ParseXML(resp.data, true);
 }
 
-minio::s3::MakeBucketResponse minio::s3::BaseClient::MakeBucket(
-    MakeBucketArgs args) {
+MakeBucketResponse BaseClient::MakeBucket(MakeBucketArgs args) {
   if (error::Error err = args.Validate()) {
     return MakeBucketResponse(err);
   }
@@ -1359,8 +1350,7 @@ minio::s3::MakeBucketResponse minio::s3::BaseClient::MakeBucket(
   return MakeBucketResponse(resp);
 }
 
-minio::s3::PutObjectResponse minio::s3::BaseClient::PutObject(
-    PutObjectApiArgs args) {
+PutObjectResponse BaseClient::PutObject(PutObjectApiArgs args) {
   if (error::Error err = args.Validate()) {
     return PutObjectResponse(err);
   }
@@ -1393,8 +1383,7 @@ minio::s3::PutObjectResponse minio::s3::BaseClient::PutObject(
   return resp;
 }
 
-minio::s3::RemoveBucketResponse minio::s3::BaseClient::RemoveBucket(
-    RemoveBucketArgs args) {
+RemoveBucketResponse BaseClient::RemoveBucket(RemoveBucketArgs args) {
   if (error::Error err = args.Validate()) {
     return RemoveBucketResponse(err);
   }
@@ -1413,8 +1402,7 @@ minio::s3::RemoveBucketResponse minio::s3::BaseClient::RemoveBucket(
   return RemoveBucketResponse(Execute(req));
 }
 
-minio::s3::RemoveObjectResponse minio::s3::BaseClient::RemoveObject(
-    RemoveObjectArgs args) {
+RemoveObjectResponse BaseClient::RemoveObject(RemoveObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return RemoveObjectResponse(err);
   }
@@ -1437,8 +1425,7 @@ minio::s3::RemoveObjectResponse minio::s3::BaseClient::RemoveObject(
   return RemoveObjectResponse(Execute(req));
 }
 
-minio::s3::RemoveObjectsResponse minio::s3::BaseClient::RemoveObjects(
-    RemoveObjectsApiArgs args) {
+RemoveObjectsResponse BaseClient::RemoveObjects(RemoveObjectsApiArgs args) {
   if (error::Error err = args.Validate()) {
     return RemoveObjectsResponse(err);
   }
@@ -1482,8 +1469,8 @@ minio::s3::RemoveObjectsResponse minio::s3::BaseClient::RemoveObjects(
   return RemoveObjectsResponse::ParseXML(response.data);
 }
 
-minio::s3::SelectObjectContentResponse
-minio::s3::BaseClient::SelectObjectContent(SelectObjectContentArgs args) {
+SelectObjectContentResponse BaseClient::SelectObjectContent(
+    SelectObjectContentArgs args) {
   if (error::Error err = args.Validate()) {
     return SelectObjectContentResponse(err);
   }
@@ -1517,8 +1504,8 @@ minio::s3::BaseClient::SelectObjectContent(SelectObjectContentArgs args) {
   return SelectObjectContentResponse(Execute(req));
 }
 
-minio::s3::SetBucketEncryptionResponse
-minio::s3::BaseClient::SetBucketEncryption(SetBucketEncryptionArgs args) {
+SetBucketEncryptionResponse BaseClient::SetBucketEncryption(
+    SetBucketEncryptionArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketEncryptionResponse(err);
   }
@@ -1552,7 +1539,7 @@ minio::s3::BaseClient::SetBucketEncryption(SetBucketEncryptionArgs args) {
   return SetBucketEncryptionResponse(Execute(req));
 }
 
-minio::s3::SetBucketLifecycleResponse minio::s3::BaseClient::SetBucketLifecycle(
+SetBucketLifecycleResponse BaseClient::SetBucketLifecycle(
     SetBucketLifecycleArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketLifecycleResponse(err);
@@ -1577,8 +1564,8 @@ minio::s3::SetBucketLifecycleResponse minio::s3::BaseClient::SetBucketLifecycle(
   return SetBucketLifecycleResponse(Execute(req));
 }
 
-minio::s3::SetBucketNotificationResponse
-minio::s3::BaseClient::SetBucketNotification(SetBucketNotificationArgs args) {
+SetBucketNotificationResponse BaseClient::SetBucketNotification(
+    SetBucketNotificationArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketNotificationResponse(err);
   }
@@ -1602,8 +1589,7 @@ minio::s3::BaseClient::SetBucketNotification(SetBucketNotificationArgs args) {
   return SetBucketNotificationResponse(Execute(req));
 }
 
-minio::s3::SetBucketPolicyResponse minio::s3::BaseClient::SetBucketPolicy(
-    SetBucketPolicyArgs args) {
+SetBucketPolicyResponse BaseClient::SetBucketPolicy(SetBucketPolicyArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketPolicyResponse(err);
   }
@@ -1625,8 +1611,8 @@ minio::s3::SetBucketPolicyResponse minio::s3::BaseClient::SetBucketPolicy(
   return SetBucketPolicyResponse(Execute(req));
 }
 
-minio::s3::SetBucketReplicationResponse
-minio::s3::BaseClient::SetBucketReplication(SetBucketReplicationArgs args) {
+SetBucketReplicationResponse BaseClient::SetBucketReplication(
+    SetBucketReplicationArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketReplicationResponse(err);
   }
@@ -1650,8 +1636,7 @@ minio::s3::BaseClient::SetBucketReplication(SetBucketReplicationArgs args) {
   return SetBucketReplicationResponse(Execute(req));
 }
 
-minio::s3::SetBucketTagsResponse minio::s3::BaseClient::SetBucketTags(
-    SetBucketTagsArgs args) {
+SetBucketTagsResponse BaseClient::SetBucketTags(SetBucketTagsArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketTagsResponse(err);
   }
@@ -1687,8 +1672,8 @@ minio::s3::SetBucketTagsResponse minio::s3::BaseClient::SetBucketTags(
   return SetBucketTagsResponse(Execute(req));
 }
 
-minio::s3::SetBucketVersioningResponse
-minio::s3::BaseClient::SetBucketVersioning(SetBucketVersioningArgs args) {
+SetBucketVersioningResponse BaseClient::SetBucketVersioning(
+    SetBucketVersioningArgs args) {
   if (error::Error err = args.Validate()) {
     return SetBucketVersioningResponse(err);
   }
@@ -1723,8 +1708,8 @@ minio::s3::BaseClient::SetBucketVersioning(SetBucketVersioningArgs args) {
   return SetBucketVersioningResponse(Execute(req));
 }
 
-minio::s3::SetObjectLockConfigResponse
-minio::s3::BaseClient::SetObjectLockConfig(SetObjectLockConfigArgs args) {
+SetObjectLockConfigResponse BaseClient::SetObjectLockConfig(
+    SetObjectLockConfigArgs args) {
   if (error::Error err = args.Validate()) {
     return SetObjectLockConfigResponse(err);
   }
@@ -1769,7 +1754,7 @@ minio::s3::BaseClient::SetObjectLockConfig(SetObjectLockConfigArgs args) {
   return SetObjectLockConfigResponse(Execute(req));
 }
 
-minio::s3::SetObjectRetentionResponse minio::s3::BaseClient::SetObjectRetention(
+SetObjectRetentionResponse BaseClient::SetObjectRetention(
     SetObjectRetentionArgs args) {
   if (error::Error err = args.Validate()) {
     return SetObjectRetentionResponse(err);
@@ -1804,8 +1789,7 @@ minio::s3::SetObjectRetentionResponse minio::s3::BaseClient::SetObjectRetention(
   return SetObjectRetentionResponse(Execute(req));
 }
 
-minio::s3::SetObjectTagsResponse minio::s3::BaseClient::SetObjectTags(
-    SetObjectTagsArgs args) {
+SetObjectTagsResponse BaseClient::SetObjectTags(SetObjectTagsArgs args) {
   if (error::Error err = args.Validate()) {
     return SetObjectTagsResponse(err);
   }
@@ -1845,8 +1829,7 @@ minio::s3::SetObjectTagsResponse minio::s3::BaseClient::SetObjectTags(
   return SetObjectTagsResponse(Execute(req));
 }
 
-minio::s3::StatObjectResponse minio::s3::BaseClient::StatObject(
-    StatObjectArgs args) {
+StatObjectResponse BaseClient::StatObject(StatObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return StatObjectResponse(err);
   }
@@ -1920,8 +1903,7 @@ minio::s3::StatObjectResponse minio::s3::BaseClient::StatObject(
   return resp;
 }
 
-minio::s3::UploadPartResponse minio::s3::BaseClient::UploadPart(
-    UploadPartArgs args) {
+UploadPartResponse BaseClient::UploadPart(UploadPartArgs args) {
   if (error::Error err = args.Validate()) {
     return UploadPartResponse(err);
   }
@@ -1944,8 +1926,7 @@ minio::s3::UploadPartResponse minio::s3::BaseClient::UploadPart(
   return UploadPartResponse(PutObject(api_args));
 }
 
-minio::s3::UploadPartCopyResponse minio::s3::BaseClient::UploadPartCopy(
-    UploadPartCopyArgs args) {
+UploadPartCopyResponse BaseClient::UploadPartCopy(UploadPartCopyArgs args) {
   if (error::Error err = args.Validate()) {
     return UploadPartCopyResponse(err);
   }
@@ -1975,3 +1956,5 @@ minio::s3::UploadPartCopyResponse minio::s3::BaseClient::UploadPartCopy(
 
   return resp;
 }
+
+}  // namespace minio::s3

--- a/src/client.cc
+++ b/src/client.cc
@@ -37,25 +37,26 @@
 #include "miniocpp/types.h"
 #include "miniocpp/utils.h"
 
-minio::s3::ListObjectsResult::ListObjectsResult(error::Error err)
-    : failed_(true) {
+namespace minio::s3 {
+
+ListObjectsResult::ListObjectsResult(error::Error err) : failed_(true) {
   this->resp_.contents.push_back(Item(std::move(err)));
   this->itr_ = resp_.contents.begin();
 }
 
-minio::s3::ListObjectsResult::ListObjectsResult(Client* const client,
-                                                const ListObjectsArgs& args)
+ListObjectsResult::ListObjectsResult(Client* const client,
+                                     const ListObjectsArgs& args)
     : client_(client), args_(args) {
   Populate();
 }
 
-minio::s3::ListObjectsResult::ListObjectsResult(Client* const client,
-                                                ListObjectsArgs&& args)
+ListObjectsResult::ListObjectsResult(Client* const client,
+                                     ListObjectsArgs&& args)
     : client_(client), args_(std::move(args)) {
   Populate();
 }
 
-void minio::s3::ListObjectsResult::Populate() {
+void ListObjectsResult::Populate() {
   if (args_.include_versions) {
     args_.key_marker = resp_.next_key_marker;
     args_.version_id_marker = resp_.next_version_id_marker;
@@ -95,25 +96,25 @@ void minio::s3::ListObjectsResult::Populate() {
   itr_ = resp_.contents.begin();
 }
 
-minio::s3::RemoveObjectsResult::RemoveObjectsResult(error::Error err) {
+RemoveObjectsResult::RemoveObjectsResult(error::Error err) {
   done_ = true;
   resp_.errors.push_back(DeleteError(err));
   itr_ = resp_.errors.begin();
 }
 
-minio::s3::RemoveObjectsResult::RemoveObjectsResult(
-    Client* const client, const RemoveObjectsArgs& args)
+RemoveObjectsResult::RemoveObjectsResult(Client* const client,
+                                         const RemoveObjectsArgs& args)
     : client_(client), args_(args) {
   Populate();
 }
 
-minio::s3::RemoveObjectsResult::RemoveObjectsResult(Client* const client,
-                                                    RemoveObjectsArgs&& args)
+RemoveObjectsResult::RemoveObjectsResult(Client* const client,
+                                         RemoveObjectsArgs&& args)
     : client_(client), args_(args) {
   Populate();
 }
 
-void minio::s3::RemoveObjectsResult::Populate() {
+void RemoveObjectsResult::Populate() {
   while (!done_ && resp_.errors.size() == 0) {
     RemoveObjectsApiArgs args;
     args.extra_headers = args_.extra_headers;
@@ -143,10 +144,10 @@ void minio::s3::RemoveObjectsResult::Populate() {
   }
 }
 
-minio::s3::Client::Client(BaseUrl& base_url, creds::Provider* const provider)
+Client::Client(BaseUrl& base_url, creds::Provider* const provider)
     : BaseClient(base_url, provider) {}
 
-minio::s3::StatObjectResponse minio::s3::Client::CalculatePartCount(
+StatObjectResponse Client::CalculatePartCount(
     size_t& part_count, std::list<ComposeSource> sources) {
   size_t object_size = 0;
   size_t i = 0;
@@ -233,8 +234,8 @@ minio::s3::StatObjectResponse minio::s3::Client::CalculatePartCount(
   return StatObjectResponse(error::SUCCESS);
 }
 
-minio::s3::ComposeObjectResponse minio::s3::Client::ComposeObject(
-    ComposeObjectArgs args, std::string& upload_id) {
+ComposeObjectResponse Client::ComposeObject(ComposeObjectArgs args,
+                                            std::string& upload_id) {
   size_t part_count = 0;
   {
     StatObjectResponse resp = CalculatePartCount(part_count, args.sources);
@@ -364,8 +365,8 @@ minio::s3::ComposeObjectResponse minio::s3::Client::ComposeObject(
   return ComposeObjectResponse(CompleteMultipartUpload(cmu_args));
 }
 
-minio::s3::PutObjectResponse minio::s3::Client::PutObject(
-    PutObjectArgs args, std::string& upload_id, char* buf) {
+PutObjectResponse Client::PutObject(PutObjectArgs args, std::string& upload_id,
+                                    char* buf) {
   utils::Multimap headers = args.Headers();
   if (!headers.Contains("Content-Type")) {
     if (args.content_type.empty()) {
@@ -537,8 +538,7 @@ minio::s3::PutObjectResponse minio::s3::Client::PutObject(
   return PutObjectResponse(resp);
 }
 
-minio::s3::ComposeObjectResponse minio::s3::Client::ComposeObject(
-    ComposeObjectArgs args) {
+ComposeObjectResponse Client::ComposeObject(ComposeObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return ComposeObjectResponse(err);
   }
@@ -562,8 +562,7 @@ minio::s3::ComposeObjectResponse minio::s3::Client::ComposeObject(
   return resp;
 }
 
-minio::s3::CopyObjectResponse minio::s3::Client::CopyObject(
-    CopyObjectArgs args) {
+CopyObjectResponse Client::CopyObject(CopyObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return CopyObjectResponse(err);
   }
@@ -669,8 +668,7 @@ minio::s3::CopyObjectResponse minio::s3::Client::CopyObject(
   return resp;
 }
 
-minio::s3::DownloadObjectResponse minio::s3::Client::DownloadObject(
-    DownloadObjectArgs args) {
+DownloadObjectResponse Client::DownloadObject(DownloadObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return DownloadObjectResponse(err);
   }
@@ -732,15 +730,14 @@ minio::s3::DownloadObjectResponse minio::s3::Client::DownloadObject(
   return DownloadObjectResponse(response);
 }
 
-minio::s3::ListObjectsResult minio::s3::Client::ListObjects(
-    ListObjectsArgs args) {
+ListObjectsResult Client::ListObjects(ListObjectsArgs args) {
   if (error::Error err = args.Validate()) {
     return ListObjectsResult(err);
   }
   return ListObjectsResult(this, std::move(args));
 }
 
-minio::s3::PutObjectResponse minio::s3::Client::PutObject(PutObjectArgs args) {
+PutObjectResponse Client::PutObject(PutObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return PutObjectResponse(err);
   }
@@ -768,8 +765,7 @@ minio::s3::PutObjectResponse minio::s3::Client::PutObject(PutObjectArgs args) {
   return resp;
 }
 
-minio::s3::UploadObjectResponse minio::s3::Client::UploadObject(
-    UploadObjectArgs args) {
+UploadObjectResponse Client::UploadObject(UploadObjectArgs args) {
   if (error::Error err = args.Validate()) {
     return UploadObjectResponse(err);
   }
@@ -802,10 +798,11 @@ minio::s3::UploadObjectResponse minio::s3::Client::UploadObject(
   return UploadObjectResponse(resp);
 }
 
-minio::s3::RemoveObjectsResult minio::s3::Client::RemoveObjects(
-    RemoveObjectsArgs args) {
+RemoveObjectsResult Client::RemoveObjects(RemoveObjectsArgs args) {
   if (error::Error err = args.Validate()) {
     return RemoveObjectsResult(err);
   }
   return RemoveObjectsResult(this, std::move(args));
 }
+
+}  // namespace minio::s3

--- a/src/credentials.cc
+++ b/src/credentials.cc
@@ -24,15 +24,17 @@
 #include "miniocpp/error.h"
 #include "miniocpp/utils.h"
 
-bool minio::creds::expired(const utils::UtcTime& expiration) {
+namespace minio::creds {
+
+bool expired(const utils::UtcTime& expiration) {
   if (!expiration) return false;
   utils::UtcTime now = utils::UtcTime::Now();
   now.Add(10);
   return expiration < now;
 }
 
-minio::creds::Credentials minio::creds::Credentials::ParseXML(
-    std::string_view data, const std::string& root) {
+Credentials Credentials::ParseXML(std::string_view data,
+                                  const std::string& root) {
   pugi::xml_document xdoc;
   pugi::xml_parse_result result = xdoc.load_string(data.data());
   if (!result) {
@@ -56,3 +58,5 @@ minio::creds::Credentials minio::creds::Credentials::ParseXML(
                      std::move(secret_key), std::move(session_token),
                      expiration);
 }
+
+}  // namespace minio::creds

--- a/src/error.cc
+++ b/src/error.cc
@@ -1,0 +1,24 @@
+// MinIO C++ Library for Amazon S3 Compatible Cloud Storage
+// Copyright 2022-2024 MinIO, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "miniocpp/error.h"
+
+namespace minio::error {
+
+const Error SUCCESS;
+
+}

--- a/src/providers.cc
+++ b/src/providers.cc
@@ -46,7 +46,9 @@
 #include <sys/socket.h>
 #endif
 
-minio::error::Error minio::creds::checkLoopbackHost(const std::string& host) {
+namespace minio::creds {
+
+error::Error checkLoopbackHost(const std::string& host) {
   struct addrinfo hints = {};
   hints.ai_family = AF_INET;
   hints.ai_socktype = SOCK_STREAM;
@@ -69,11 +71,11 @@ minio::error::Error minio::creds::checkLoopbackHost(const std::string& host) {
   return error::SUCCESS;
 }
 
-minio::creds::Provider::~Provider() {}
+Provider::~Provider() {}
 
-minio::creds::ChainedProvider::~ChainedProvider() {}
+ChainedProvider::~ChainedProvider() {}
 
-minio::creds::Credentials minio::creds::ChainedProvider::Fetch() {
+Credentials ChainedProvider::Fetch() {
   if (err_) return Credentials{err_};
 
   if (creds_) return creds_;
@@ -92,20 +94,17 @@ minio::creds::Credentials minio::creds::ChainedProvider::Fetch() {
   return error::make<Credentials>("All providers fail to fetch credentials");
 }
 
-minio::creds::StaticProvider::StaticProvider(std::string access_key,
-                                             std::string secret_key,
-                                             std::string session_token) {
+StaticProvider::StaticProvider(std::string access_key, std::string secret_key,
+                               std::string session_token) {
   this->creds_ = Credentials(error::SUCCESS, std::move(access_key),
                              std::move(secret_key), std::move(session_token));
 }
 
-minio::creds::StaticProvider::~StaticProvider() {}
+StaticProvider::~StaticProvider() {}
 
-minio::creds::Credentials minio::creds::StaticProvider::Fetch() {
-  return creds_;
-}
+Credentials StaticProvider::Fetch() { return creds_; }
 
-minio::creds::EnvAwsProvider::EnvAwsProvider() {
+EnvAwsProvider::EnvAwsProvider() {
   std::string access_key;
   std::string secret_key;
   std::string session_token;
@@ -122,13 +121,11 @@ minio::creds::EnvAwsProvider::EnvAwsProvider() {
                              std::move(secret_key), std::move(session_token));
 }
 
-minio::creds::EnvAwsProvider::~EnvAwsProvider() {}
+EnvAwsProvider::~EnvAwsProvider() {}
 
-minio::creds::Credentials minio::creds::EnvAwsProvider::Fetch() {
-  return creds_;
-}
+Credentials EnvAwsProvider::Fetch() { return creds_; }
 
-minio::creds::EnvMinioProvider::EnvMinioProvider() {
+EnvMinioProvider::EnvMinioProvider() {
   std::string access_key;
   std::string secret_key;
 
@@ -138,14 +135,12 @@ minio::creds::EnvMinioProvider::EnvMinioProvider() {
       Credentials(error::SUCCESS, std::move(access_key), std::move(secret_key));
 }
 
-minio::creds::EnvMinioProvider::~EnvMinioProvider() {}
+EnvMinioProvider::~EnvMinioProvider() {}
 
-minio::creds::Credentials minio::creds::EnvMinioProvider::Fetch() {
-  return creds_;
-}
+Credentials EnvMinioProvider::Fetch() { return creds_; }
 
-minio::creds::AwsConfigProvider::AwsConfigProvider(std::string filename,
-                                                   std::string profile) {
+AwsConfigProvider::AwsConfigProvider(std::string filename,
+                                     std::string profile) {
   if (filename.empty()) {
     if (!utils::GetEnv(filename, "AWS_SHARED_CREDENTIALS_FILE")) {
       filename = utils::GetHomeDir() + "/aws/credentials";
@@ -167,14 +162,12 @@ minio::creds::AwsConfigProvider::AwsConfigProvider(std::string filename,
   }
 }
 
-minio::creds::AwsConfigProvider::~AwsConfigProvider() {}
+AwsConfigProvider::~AwsConfigProvider() {}
 
-minio::creds::Credentials minio::creds::AwsConfigProvider::Fetch() {
-  return creds_;
-}
+Credentials AwsConfigProvider::Fetch() { return creds_; }
 
-minio::creds::MinioClientConfigProvider::MinioClientConfigProvider(
-    std::string filename, std::string alias) {
+MinioClientConfigProvider::MinioClientConfigProvider(std::string filename,
+                                                     std::string alias) {
   if (filename.empty()) filename = utils::GetHomeDir() + "/.mc/config.json";
 
   if (alias.empty()) {
@@ -207,13 +200,11 @@ minio::creds::MinioClientConfigProvider::MinioClientConfigProvider(
                              aliases[alias]["secretKey"]};
 }
 
-minio::creds::MinioClientConfigProvider::~MinioClientConfigProvider() {}
+MinioClientConfigProvider::~MinioClientConfigProvider() {}
 
-minio::creds::Credentials minio::creds::MinioClientConfigProvider::Fetch() {
-  return creds_;
-}
+Credentials MinioClientConfigProvider::Fetch() { return creds_; }
 
-minio::creds::AssumeRoleProvider::AssumeRoleProvider(
+AssumeRoleProvider::AssumeRoleProvider(
     http::Url sts_endpoint, std::string access_key, std::string secret_key,
     unsigned int duration_seconds, std::string policy, std::string region,
     std::string role_arn, std::string role_session_name,
@@ -242,9 +233,9 @@ minio::creds::AssumeRoleProvider::AssumeRoleProvider(
   this->content_sha256_ = utils::Sha256Hash(body_);
 }
 
-minio::creds::AssumeRoleProvider::~AssumeRoleProvider() {}
+AssumeRoleProvider::~AssumeRoleProvider() {}
 
-minio::creds::Credentials minio::creds::AssumeRoleProvider::Fetch() {
+Credentials AssumeRoleProvider::Fetch() {
   if (err_) return Credentials{err_};
 
   if (creds_) return creds_;
@@ -273,7 +264,7 @@ minio::creds::Credentials minio::creds::AssumeRoleProvider::Fetch() {
   return creds_;
 }
 
-minio::creds::WebIdentityClientGrantsProvider::WebIdentityClientGrantsProvider(
+WebIdentityClientGrantsProvider::WebIdentityClientGrantsProvider(
     JwtFunction jwtfunc, http::Url sts_endpoint, unsigned int duration_seconds,
     std::string policy, std::string role_arn, std::string role_session_name) {
   this->jwtfunc_ = jwtfunc;
@@ -284,10 +275,9 @@ minio::creds::WebIdentityClientGrantsProvider::WebIdentityClientGrantsProvider(
   this->role_session_name_ = role_session_name;
 }
 
-minio::creds::WebIdentityClientGrantsProvider::
-    ~WebIdentityClientGrantsProvider() {}
+WebIdentityClientGrantsProvider::~WebIdentityClientGrantsProvider() {}
 
-unsigned int minio::creds::WebIdentityClientGrantsProvider::getDurationSeconds(
+unsigned int WebIdentityClientGrantsProvider::getDurationSeconds(
     unsigned int expiry) const {
   if (duration_seconds_) expiry = duration_seconds_;
   if (expiry > MAX_DURATION_SECONDS) return MAX_DURATION_SECONDS;
@@ -296,8 +286,7 @@ unsigned int minio::creds::WebIdentityClientGrantsProvider::getDurationSeconds(
   return expiry;
 }
 
-minio::creds::Credentials
-minio::creds::WebIdentityClientGrantsProvider::Fetch() {
+Credentials WebIdentityClientGrantsProvider::Fetch() {
   if (creds_) return creds_;
 
   Jwt jwt = jwtfunc_();
@@ -340,27 +329,27 @@ minio::creds::WebIdentityClientGrantsProvider::Fetch() {
   return creds_;
 }
 
-minio::creds::ClientGrantsProvider::ClientGrantsProvider(
+ClientGrantsProvider::ClientGrantsProvider(
     JwtFunction jwtfunc, http::Url sts_endpoint, unsigned int duration_seconds,
     std::string policy, std::string role_arn, std::string role_session_name)
     : WebIdentityClientGrantsProvider(jwtfunc, sts_endpoint, duration_seconds,
                                       policy, role_arn, role_session_name) {}
 
-minio::creds::ClientGrantsProvider::~ClientGrantsProvider() {}
+ClientGrantsProvider::~ClientGrantsProvider() {}
 
-bool minio::creds::ClientGrantsProvider::IsWebIdentity() const { return false; }
+bool ClientGrantsProvider::IsWebIdentity() const { return false; }
 
-minio::creds::WebIdentityProvider::WebIdentityProvider(
+WebIdentityProvider::WebIdentityProvider(
     JwtFunction jwtfunc, http::Url sts_endpoint, unsigned int duration_seconds,
     std::string policy, std::string role_arn, std::string role_session_name)
     : WebIdentityClientGrantsProvider(jwtfunc, sts_endpoint, duration_seconds,
                                       policy, role_arn, role_session_name) {}
 
-minio::creds::WebIdentityProvider::~WebIdentityProvider() {}
+WebIdentityProvider::~WebIdentityProvider() {}
 
-bool minio::creds::WebIdentityProvider::IsWebIdentity() const { return true; }
+bool WebIdentityProvider::IsWebIdentity() const { return true; }
 
-minio::creds::IamAwsProvider::IamAwsProvider(http::Url custom_endpoint) {
+IamAwsProvider::IamAwsProvider(http::Url custom_endpoint) {
   this->custom_endpoint_ = custom_endpoint;
   utils::GetEnv(this->token_file_, "AWS_WEB_IDENTITY_TOKEN_FILE");
   utils::GetEnv(this->aws_region_, "AWS_REGION");
@@ -373,9 +362,9 @@ minio::creds::IamAwsProvider::IamAwsProvider(http::Url custom_endpoint) {
   utils::GetEnv(this->full_uri_, "AWS_CONTAINER_CREDENTIALS_FULL_URI");
 }
 
-minio::creds::IamAwsProvider::~IamAwsProvider() {}
+IamAwsProvider::~IamAwsProvider() {}
 
-minio::creds::Credentials minio::creds::IamAwsProvider::Fetch() {
+Credentials IamAwsProvider::Fetch() {
   if (creds_) return creds_;
 
   http::Url url = custom_endpoint_;
@@ -432,7 +421,7 @@ minio::creds::Credentials minio::creds::IamAwsProvider::Fetch() {
   return creds_;
 }
 
-minio::creds::Credentials minio::creds::IamAwsProvider::fetch(http::Url url) {
+Credentials IamAwsProvider::fetch(http::Url url) {
   http::Request req(http::Method::kGet, url);
   http::Response resp = req.Execute();
   if (!resp) return Credentials{resp.Error()};
@@ -451,8 +440,8 @@ minio::creds::Credentials minio::creds::IamAwsProvider::fetch(http::Url url) {
                      utils::UtcTime::FromISO8601UTC(expiration.c_str())};
 }
 
-minio::error::Error minio::creds::IamAwsProvider::getRoleName(
-    std::string& role_name, http::Url url) const {
+error::Error IamAwsProvider::getRoleName(std::string& role_name,
+                                         http::Url url) const {
   http::Request req(http::Method::kGet, url);
   http::Response resp = req.Execute();
   if (!resp) return resp.Error();
@@ -475,9 +464,9 @@ minio::error::Error minio::creds::IamAwsProvider::getRoleName(
   return error::SUCCESS;
 }
 
-minio::creds::LdapIdentityProvider::LdapIdentityProvider(
-    http::Url sts_endpoint, std::string ldap_username,
-    std::string ldap_password) {
+LdapIdentityProvider::LdapIdentityProvider(http::Url sts_endpoint,
+                                           std::string ldap_username,
+                                           std::string ldap_password) {
   this->sts_endpoint_ = sts_endpoint;
   utils::Multimap map;
   map.Add("Action", "AssumeRoleWithLDAPIdentity");
@@ -487,9 +476,9 @@ minio::creds::LdapIdentityProvider::LdapIdentityProvider(
   this->sts_endpoint_.query_string = map.ToQueryString();
 }
 
-minio::creds::LdapIdentityProvider::~LdapIdentityProvider() {}
+LdapIdentityProvider::~LdapIdentityProvider() {}
 
-minio::creds::Credentials minio::creds::LdapIdentityProvider::Fetch() {
+Credentials LdapIdentityProvider::Fetch() {
   if (creds_) return creds_;
 
   http::Request req(http::Method::kPost, sts_endpoint_);
@@ -500,7 +489,7 @@ minio::creds::Credentials minio::creds::LdapIdentityProvider::Fetch() {
   return creds_;
 }
 
-minio::creds::CertificateIdentityProvider::CertificateIdentityProvider(
+CertificateIdentityProvider::CertificateIdentityProvider(
     http::Url sts_endpoint, std::string key_file, std::string cert_file,
     std::string ssl_cert_file, unsigned int duration_seconds) {
   if (!sts_endpoint.https) {
@@ -530,9 +519,9 @@ minio::creds::CertificateIdentityProvider::CertificateIdentityProvider(
   ssl_cert_file_ = ssl_cert_file;
 }
 
-minio::creds::CertificateIdentityProvider::~CertificateIdentityProvider() {}
+CertificateIdentityProvider::~CertificateIdentityProvider() {}
 
-minio::creds::Credentials minio::creds::CertificateIdentityProvider::Fetch() {
+Credentials CertificateIdentityProvider::Fetch() {
   if (err_) return Credentials{err_};
 
   if (creds_) return creds_;
@@ -548,3 +537,5 @@ minio::creds::Credentials minio::creds::CertificateIdentityProvider::Fetch() {
   creds_ = Credentials::ParseXML(resp.body, "AssumeRoleWithCertificateResult");
   return creds_;
 }
+
+}  // namespace minio::creds

--- a/src/response.cc
+++ b/src/response.cc
@@ -29,11 +29,13 @@
 #include "miniocpp/types.h"
 #include "miniocpp/utils.h"
 
-minio::s3::Response::Response() {}
+namespace minio::s3 {
 
-minio::s3::Response::~Response() {}
+Response::Response() {}
 
-minio::error::Error minio::s3::Response::Error() const {
+Response::~Response() {}
+
+error::Error Response::Error() const {
   if (err_) return err_;
   if (!code.empty()) {
     return error::Error(code + ": " + message);
@@ -45,9 +47,8 @@ minio::error::Error minio::s3::Response::Error() const {
   return error::SUCCESS;
 }
 
-minio::s3::Response minio::s3::Response::ParseXML(std::string_view data,
-                                                  int status_code,
-                                                  utils::Multimap headers) {
+Response Response::ParseXML(std::string_view data, int status_code,
+                            utils::Multimap headers) {
   Response resp;
   resp.status_code = status_code;
   resp.headers = headers;
@@ -86,8 +87,7 @@ minio::s3::Response minio::s3::Response::ParseXML(std::string_view data,
   return resp;
 }
 
-minio::s3::ListBucketsResponse minio::s3::ListBucketsResponse::ParseXML(
-    std::string_view data) {
+ListBucketsResponse ListBucketsResponse::ParseXML(std::string_view data) {
   std::list<Bucket> buckets;
 
   pugi::xml_document xdoc;
@@ -114,9 +114,8 @@ minio::s3::ListBucketsResponse minio::s3::ListBucketsResponse::ParseXML(
   return ListBucketsResponse(buckets);
 }
 
-minio::s3::CompleteMultipartUploadResponse
-minio::s3::CompleteMultipartUploadResponse::ParseXML(std::string_view data,
-                                                     std::string version_id) {
+CompleteMultipartUploadResponse CompleteMultipartUploadResponse::ParseXML(
+    std::string_view data, std::string version_id) {
   CompleteMultipartUploadResponse resp;
 
   pugi::xml_document xdoc;
@@ -145,8 +144,8 @@ minio::s3::CompleteMultipartUploadResponse::ParseXML(std::string_view data,
   return resp;
 }
 
-minio::s3::ListObjectsResponse minio::s3::ListObjectsResponse::ParseXML(
-    std::string_view data, bool version) {
+ListObjectsResponse ListObjectsResponse::ParseXML(std::string_view data,
+                                                  bool version) {
   ListObjectsResponse resp;
 
   pugi::xml_document xdoc;
@@ -180,7 +179,7 @@ minio::s3::ListObjectsResponse minio::s3::ListObjectsResponse::ParseXML(
 
   text = root.node().select_node("MaxKeys/text()");
   value = text.node().value();
-  if (!value.empty()) resp.max_keys = std::stoi(value);
+  if (!value.empty()) resp.max_keys = static_cast<unsigned>(std::stoul(value));
 
   // ListBucketResult V1
   {
@@ -199,7 +198,8 @@ minio::s3::ListObjectsResponse minio::s3::ListObjectsResponse::ParseXML(
   {
     text = root.node().select_node("KeyCount/text()");
     value = text.node().value();
-    if (!value.empty()) resp.key_count = std::stoi(value);
+    if (!value.empty())
+      resp.key_count = static_cast<unsigned>(std::stoul(value));
 
     text = root.node().select_node("StartAfter/text()");
     value = text.node().value();
@@ -262,7 +262,7 @@ minio::s3::ListObjectsResponse minio::s3::ListObjectsResponse::ParseXML(
 
       text = content.node().select_node("Size/text()");
       value = text.node().value();
-      if (!value.empty()) item.size = std::stol(value);
+      if (!value.empty()) item.size = static_cast<size_t>(std::stoull(value));
 
       text = content.node().select_node("StorageClass/text()");
       item.storage_class = text.node().value();
@@ -313,8 +313,7 @@ minio::s3::ListObjectsResponse minio::s3::ListObjectsResponse::ParseXML(
   return resp;
 }
 
-minio::s3::RemoveObjectsResponse minio::s3::RemoveObjectsResponse::ParseXML(
-    std::string_view data) {
+RemoveObjectsResponse RemoveObjectsResponse::ParseXML(std::string_view data) {
   RemoveObjectsResponse resp;
 
   pugi::xml_document xdoc;
@@ -370,9 +369,9 @@ minio::s3::RemoveObjectsResponse minio::s3::RemoveObjectsResponse::ParseXML(
   return resp;
 }
 
-minio::s3::GetBucketNotificationResponse
-minio::s3::GetBucketNotificationResponse::ParseXML(std::string_view data) {
-  minio::s3::NotificationConfig config;
+GetBucketNotificationResponse GetBucketNotificationResponse::ParseXML(
+    std::string_view data) {
+  NotificationConfig config;
 
   pugi::xml_document xdoc;
   pugi::xml_parse_result result = xdoc.load_string(data.data());
@@ -465,8 +464,8 @@ minio::s3::GetBucketNotificationResponse::ParseXML(std::string_view data) {
   return GetBucketNotificationResponse(config);
 }
 
-minio::s3::GetBucketEncryptionResponse
-minio::s3::GetBucketEncryptionResponse::ParseXML(std::string_view data) {
+GetBucketEncryptionResponse GetBucketEncryptionResponse::ParseXML(
+    std::string_view data) {
   SseConfig config;
 
   pugi::xml_document xdoc;
@@ -487,8 +486,8 @@ minio::s3::GetBucketEncryptionResponse::ParseXML(std::string_view data) {
   return GetBucketEncryptionResponse(config);
 }
 
-minio::s3::GetBucketReplicationResponse
-minio::s3::GetBucketReplicationResponse::ParseXML(std::string_view data) {
+GetBucketReplicationResponse GetBucketReplicationResponse::ParseXML(
+    std::string_view data) {
   ReplicationConfig config;
 
   pugi::xml_document xdoc;
@@ -547,7 +546,8 @@ minio::s3::GetBucketReplicationResponse::ParseXML(std::string_view data) {
       text = destination.node().select_node(
           "Metrics/EventThreshold/Minutes/text()");
       value = text.node().value();
-      rrule.destination.metrics.event_threshold_minutes = std::stoi(value);
+      rrule.destination.metrics.event_threshold_minutes =
+          static_cast<unsigned>(std::stoul(value));
 
       text = destination.node().select_node(
           "Metrics/EventThreshold/Status/text()");
@@ -559,7 +559,8 @@ minio::s3::GetBucketReplicationResponse::ParseXML(std::string_view data) {
 
       text = destination.node().select_node("ReplicationTime/Time/text()");
       value = text.node().value();
-      rrule.destination.replication_time.time_minutes = std::stoi(value);
+      rrule.destination.replication_time.time_minutes =
+          static_cast<unsigned>(std::stoul(value));
 
       text = destination.node().select_node("ReplicationTime/Status/text()");
       value = text.node().value();
@@ -651,8 +652,8 @@ minio::s3::GetBucketReplicationResponse::ParseXML(std::string_view data) {
   return GetBucketReplicationResponse(config);
 }
 
-minio::s3::GetBucketLifecycleResponse
-minio::s3::GetBucketLifecycleResponse::ParseXML(std::string_view data) {
+GetBucketLifecycleResponse GetBucketLifecycleResponse::ParseXML(
+    std::string_view data) {
   LifecycleConfig config;
 
   pugi::xml_document xdoc;
@@ -779,8 +780,7 @@ minio::s3::GetBucketLifecycleResponse::ParseXML(std::string_view data) {
   return GetBucketLifecycleResponse(config);
 }
 
-minio::s3::GetBucketTagsResponse minio::s3::GetBucketTagsResponse::ParseXML(
-    std::string_view data) {
+GetBucketTagsResponse GetBucketTagsResponse::ParseXML(std::string_view data) {
   std::map<std::string, std::string> map;
 
   pugi::xml_document xdoc;
@@ -805,8 +805,7 @@ minio::s3::GetBucketTagsResponse minio::s3::GetBucketTagsResponse::ParseXML(
   return map;
 }
 
-minio::s3::GetObjectTagsResponse minio::s3::GetObjectTagsResponse::ParseXML(
-    std::string_view data) {
+GetObjectTagsResponse GetObjectTagsResponse::ParseXML(std::string_view data) {
   std::map<std::string, std::string> map;
 
   pugi::xml_document xdoc;
@@ -830,3 +829,5 @@ minio::s3::GetObjectTagsResponse minio::s3::GetObjectTagsResponse::ParseXML(
 
   return map;
 }
+
+}  // namespace minio::s3

--- a/src/sse.cc
+++ b/src/sse.cc
@@ -21,55 +21,53 @@
 
 #include "miniocpp/utils.h"
 
-minio::s3::Sse::Sse() {}
+namespace minio::s3 {
 
-minio::s3::Sse::~Sse() {}
+Sse::Sse() {}
 
-minio::utils::Multimap minio::s3::Sse::Headers() const { return headers_; }
+Sse::~Sse() {}
 
-minio::utils::Multimap minio::s3::Sse::CopyHeaders() const {
-  return copy_headers_;
-}
+utils::Multimap Sse::Headers() const { return headers_; }
 
-minio::s3::SseCustomerKey::SseCustomerKey(std::string_view key) {
+utils::Multimap Sse::CopyHeaders() const { return copy_headers_; }
+
+SseCustomerKey::SseCustomerKey(std::string_view key) {
   std::string b64key = utils::Base64Encode(key);
   std::string md5key = utils::Md5sumHash(key);
 
-  this->headers_.Add("X-Amz-Server-Side-Encryption-Customer-Algorithm",
-                     "AES256");
-  this->headers_.Add("X-Amz-Server-Side-Encryption-Customer-Key", b64key);
-  this->headers_.Add("X-Amz-Server-Side-Encryption-Customer-Key-MD5", md5key);
+  headers_.Add("X-Amz-Server-Side-Encryption-Customer-Algorithm", "AES256");
+  headers_.Add("X-Amz-Server-Side-Encryption-Customer-Key", b64key);
+  headers_.Add("X-Amz-Server-Side-Encryption-Customer-Key-MD5", md5key);
 
-  this->copy_headers_.Add(
+  copy_headers_.Add(
       "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Algorithm", "AES256");
-  this->copy_headers_.Add(
-      "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key", b64key);
-  this->copy_headers_.Add(
-      "X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-MD5", md5key);
+  copy_headers_.Add("X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key",
+                    b64key);
+  copy_headers_.Add("X-Amz-Copy-Source-Server-Side-Encryption-Customer-Key-MD5",
+                    md5key);
 }
 
-minio::s3::SseCustomerKey::~SseCustomerKey() {}
+SseCustomerKey::~SseCustomerKey() {}
 
-bool minio::s3::SseCustomerKey::TlsRequired() const { return true; }
+bool SseCustomerKey::TlsRequired() const { return true; }
 
-minio::s3::SseKms::SseKms(std::string_view key, std::string_view context) {
-  this->headers_.Add("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id",
-                     std::string(key));
-  this->headers_.Add("X-Amz-Server-Side-Encryption", "aws:kms");
+SseKms::SseKms(std::string_view key, std::string_view context) {
+  headers_.Add("X-Amz-Server-Side-Encryption-Aws-Kms-Key-Id", std::string(key));
+  headers_.Add("X-Amz-Server-Side-Encryption", "aws:kms");
   if (!context.empty()) {
-    this->headers_.Add("X-Amz-Server-Side-Encryption-Context",
-                       utils::Base64Encode(context));
+    headers_.Add("X-Amz-Server-Side-Encryption-Context",
+                 utils::Base64Encode(context));
   }
 }
 
-minio::s3::SseKms::~SseKms() {}
+SseKms::~SseKms() {}
 
-bool minio::s3::SseKms::TlsRequired() const { return true; }
+bool SseKms::TlsRequired() const { return true; }
 
-minio::s3::SseS3::SseS3() {
-  this->headers_.Add("X-Amz-Server-Side-Encryption", "AES256");
-}
+SseS3::SseS3() { headers_.Add("X-Amz-Server-Side-Encryption", "AES256"); }
 
-minio::s3::SseS3::~SseS3() {}
+SseS3::~SseS3() {}
 
-bool minio::s3::SseS3::TlsRequired() const { return false; }
+bool SseS3::TlsRequired() const { return false; }
+
+}  // namespace minio::s3

--- a/src/types.cc
+++ b/src/types.cc
@@ -27,8 +27,9 @@
 
 #include "miniocpp/error.h"
 
-minio::s3::RetentionMode minio::s3::StringToRetentionMode(
-    std::string_view str) noexcept {
+namespace minio::s3 {
+
+RetentionMode StringToRetentionMode(std::string_view str) noexcept {
   if (str == "GOVERNANCE") return RetentionMode::kGovernance;
   if (str == "COMPLIANCE") return RetentionMode::kCompliance;
 
@@ -39,8 +40,7 @@ minio::s3::RetentionMode minio::s3::StringToRetentionMode(
   return RetentionMode::kGovernance;  // never reaches here.
 }
 
-minio::s3::LegalHold minio::s3::StringToLegalHold(
-    std::string_view str) noexcept {
+LegalHold StringToLegalHold(std::string_view str) noexcept {
   if (str == "ON") return LegalHold::kOn;
   if (str == "OFF") return LegalHold::kOff;
 
@@ -51,8 +51,7 @@ minio::s3::LegalHold minio::s3::StringToLegalHold(
   return LegalHold::kOff;  // never reaches here.
 }
 
-minio::s3::Directive minio::s3::StringToDirective(
-    std::string_view str) noexcept {
+Directive StringToDirective(std::string_view str) noexcept {
   if (str == "COPY") return Directive::kCopy;
   if (str == "REPLACE") return Directive::kReplace;
 
@@ -62,7 +61,7 @@ minio::s3::Directive minio::s3::StringToDirective(
   return Directive::kCopy;  // never reaches here.
 }
 
-std::string minio::s3::SelectRequest::ToXML() const {
+std::string SelectRequest::ToXML() const {
   std::stringstream ss;
   ss << "<SelectObjectContentRequest>";
 
@@ -180,9 +179,8 @@ std::string minio::s3::SelectRequest::ToXML() const {
   return ss.str();
 }
 
-minio::s3::NotificationRecord minio::s3::NotificationRecord::ParseJSON(
-    nlohmann::json j_record) {
-  minio::s3::NotificationRecord record;
+NotificationRecord NotificationRecord::ParseJSON(nlohmann::json j_record) {
+  NotificationRecord record;
 
   record.event_version = j_record.value("eventVersion", "");
   record.event_source = j_record.value("eventSource", "");
@@ -225,7 +223,7 @@ minio::s3::NotificationRecord minio::s3::NotificationRecord::ParseJSON(
     if (j_s3.contains("object")) {
       auto& j_object = j_s3["object"];
       record.s3.object.key = j_object.value("key", "");
-      record.s3.object.size = j_object.value("size", 0);
+      record.s3.object.size = j_object.value("size", size_t(0));
       record.s3.object.etag = j_object.value("eTag", "");
       record.s3.object.content_type = j_object.value("contentType", "");
       record.s3.object.sequencer = j_object.value("sequencer", "");
@@ -246,7 +244,7 @@ minio::s3::NotificationRecord minio::s3::NotificationRecord::ParseJSON(
   return record;
 }
 
-std::string minio::s3::NotificationConfig::ToXML() const {
+std::string NotificationConfig::ToXML() const {
   std::stringstream ss;
   ss << "<NotificationConfiguration>";
 
@@ -321,7 +319,7 @@ std::string minio::s3::NotificationConfig::ToXML() const {
   return ss.str();
 }
 
-std::string minio::s3::ReplicationConfig::ToXML() const {
+std::string ReplicationConfig::ToXML() const {
   auto status_xml = [](bool status) -> std::string {
     std::stringstream ss;
     ss << "<Status>" << (status ? "Enabled" : "Disabled") << "</Status>";
@@ -463,7 +461,7 @@ std::string minio::s3::ReplicationConfig::ToXML() const {
   return ss.str();
 }
 
-minio::error::Error minio::s3::LifecycleRule::Validate() const {
+error::Error LifecycleRule::Validate() const {
   if (!abort_incomplete_multipart_upload_days_after_initiation &&
       !expiration_date && !expiration_days &&
       !expiration_expired_object_delete_marker &&
@@ -502,7 +500,7 @@ minio::error::Error minio::s3::LifecycleRule::Validate() const {
   return error::SUCCESS;
 }
 
-std::string minio::s3::LifecycleConfig::ToXML() const {
+std::string LifecycleConfig::ToXML() const {
   std::stringstream ss;
 
   ss << "<LifecycleConfiguration>";
@@ -606,7 +604,7 @@ std::string minio::s3::LifecycleConfig::ToXML() const {
   return ss.str();
 }
 
-minio::error::Error minio::s3::ObjectLockConfig::Validate() const {
+error::Error ObjectLockConfig::Validate() const {
   if (IsRetentionModeValid(retention_mode)) {
     if (!(static_cast<bool>(retention_duration_days) ^
           static_cast<bool>(retention_duration_years))) {
@@ -623,15 +621,17 @@ minio::error::Error minio::s3::ObjectLockConfig::Validate() const {
   return error::SUCCESS;
 }
 
-minio::s3::SseConfig minio::s3::SseConfig::S3() {
+SseConfig SseConfig::S3() {
   SseConfig config;
   config.sse_algorithm = "AES256";
   return config;
 }
 
-minio::s3::SseConfig minio::s3::SseConfig::Kms(std::string masterkeyid) {
+SseConfig SseConfig::Kms(std::string masterkeyid) {
   SseConfig config;
   config.sse_algorithm = "aws:kms";
   config.kms_master_key_id = masterkeyid;
   return config;
 }
+
+}  // namespace minio::s3

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -59,16 +59,19 @@
 #include <type_traits>
 #include <vector>
 
-const std::string WEEK_DAYS[] = {"Sun", "Mon", "Tue", "Wed",
-                                 "Thu", "Fri", "Sat"};
-const std::string MONTHS[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                              "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-const std::regex MULTI_SPACE_REGEX("( +)");
+namespace minio::utils {
 
-const std::regex BUCKET_NAME_REGEX("^[a-z0-9][a-z0-9\\.\\-]{1,61}[a-z0-9]$");
-const std::regex OLD_BUCKET_NAME_REGEX(
+static const std::string WEEK_DAYS[] = {"Sun", "Mon", "Tue", "Wed",
+                                        "Thu", "Fri", "Sat"};
+static const std::string MONTHS[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                                     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+static const std::regex MULTI_SPACE_REGEX("( +)");
+
+static const std::regex BUCKET_NAME_REGEX(
+    "^[a-z0-9][a-z0-9\\.\\-]{1,61}[a-z0-9]$");
+static const std::regex OLD_BUCKET_NAME_REGEX(
     "^[a-z0-9][a-z0-9_\\.\\-\\:]{1,61}[a-z0-9]$", std::regex_constants::icase);
-const std::regex IPV4_REGEX(
+static const std::regex IPV4_REGEX(
     "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}"
     "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$");
 
@@ -85,7 +88,7 @@ static char* strptime(const char* s, const char* f, struct tm* tm) {
 }
 #endif
 
-bool minio::utils::GetEnv(std::string& var, const char* name) {
+bool GetEnv(std::string& var, const char* name) {
   if (const char* value = std::getenv(name)) {
     var = value;
     return true;
@@ -93,7 +96,7 @@ bool minio::utils::GetEnv(std::string& var, const char* name) {
   return false;
 }
 
-std::string minio::utils::GetHomeDir() {
+std::string GetHomeDir() {
   std::string home;
 #ifdef _WIN32
   GetEnv(home, "USERPROFILE");
@@ -104,7 +107,7 @@ std::string minio::utils::GetHomeDir() {
 #endif
 }
 
-std::string minio::utils::Printable(const std::string& s) {
+std::string Printable(const std::string& s) {
   std::stringstream ss;
   for (auto& ch : s) {
     if (ch < 33 || ch > 126) {
@@ -118,17 +121,20 @@ std::string minio::utils::Printable(const std::string& s) {
   return ss.str();
 }
 
-unsigned long minio::utils::CRC32(std::string_view str) {
+unsigned long CRC32(std::string_view str) {
   return crc32(0, reinterpret_cast<const unsigned char*>(str.data()),
                static_cast<uInt>(str.size()));
 }
 
-unsigned int minio::utils::Int(std::string_view str) {
-  unsigned char* data = (unsigned char*)str.data();
-  return data[0] << 24 | data[1] << 16 | data[2] << 8 | data[3];
+unsigned int Int(std::string_view str) {
+  const unsigned char* data =
+      reinterpret_cast<const unsigned char*>(str.data());
+
+  return (unsigned(data[0]) << 24) | (unsigned(data[1]) << 16) |
+         (unsigned(data[2]) << 8) | (unsigned(data[3]));
 }
 
-bool minio::utils::StringToBool(const std::string& str) {
+bool StringToBool(const std::string& str) {
   std::string s = ToLower(str);
   if (s == "false") return false;
   if (s == "true") return true;
@@ -140,43 +146,43 @@ bool minio::utils::StringToBool(const std::string& str) {
   return false;
 }
 
-std::string minio::utils::Trim(std::string_view str, char ch) {
+std::string Trim(std::string_view str, char ch) {
   std::size_t start, len;
   for (start = 0; start < str.size() && str[start] == ch; start++);
   for (len = str.size() - start; len > 0 && str[start + len - 1] == ch; len--);
   return std::string(str.substr(start, len));
 }
 
-bool minio::utils::CheckNonEmptyString(std::string_view str) {
+bool CheckNonEmptyString(std::string_view str) {
   return !str.empty() && Trim(str) == str;
 }
 
-std::string minio::utils::ToLower(const std::string& str) {
+std::string ToLower(const std::string& str) {
   std::string s(str);
   std::transform(s.begin(), s.end(), s.begin(), ::tolower);
   return s;
 }
 
-bool minio::utils::StartsWith(std::string_view str, std::string_view prefix) {
+bool StartsWith(std::string_view str, std::string_view prefix) {
   return (str.size() >= prefix.size() &&
           str.compare(0, prefix.size(), prefix) == 0);
 }
 
-bool minio::utils::EndsWith(std::string_view str, std::string_view suffix) {
+bool EndsWith(std::string_view str, std::string_view suffix) {
   return (str.size() >= suffix.size() &&
           str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0);
 }
 
-bool minio::utils::Contains(std::string_view str, char ch) {
+bool Contains(std::string_view str, char ch) {
   return str.find(ch) != std::string::npos;
 }
 
-bool minio::utils::Contains(std::string_view str, std::string_view substr) {
+bool Contains(std::string_view str, std::string_view substr) {
   return str.find(substr) != std::string::npos;
 }
 
-std::string minio::utils::Join(const std::list<std::string>& values,
-                               const std::string& delimiter) {
+std::string Join(const std::list<std::string>& values,
+                 const std::string& delimiter) {
   std::string result;
   for (const auto& value : values) {
     if (!result.empty()) result += delimiter;
@@ -185,8 +191,8 @@ std::string minio::utils::Join(const std::list<std::string>& values,
   return result;
 }
 
-std::string minio::utils::Join(const std::vector<std::string>& values,
-                               const std::string& delimiter) {
+std::string Join(const std::vector<std::string>& values,
+                 const std::string& delimiter) {
   std::string result;
   for (const auto& value : values) {
     if (!result.empty()) result += delimiter;
@@ -195,7 +201,7 @@ std::string minio::utils::Join(const std::vector<std::string>& values,
   return result;
 }
 
-std::string minio::utils::EncodePath(const std::string& path) {
+std::string EncodePath(const std::string& path) {
   std::stringstream str_stream(path);
   std::string token;
   std::string out;
@@ -212,7 +218,7 @@ std::string minio::utils::EncodePath(const std::string& path) {
   return out;
 }
 
-std::string minio::utils::Sha256Hash(std::string_view str) {
+std::string Sha256Hash(std::string_view str) {
   EVP_MD_CTX* ctx = EVP_MD_CTX_create();
   if (ctx == nullptr) {
     std::cerr << "failed to create EVP_MD_CTX" << std::endl;
@@ -229,7 +235,7 @@ std::string minio::utils::Sha256Hash(std::string_view str) {
     std::terminate();
   }
 
-  unsigned int length = EVP_MD_size(EVP_sha256());
+  unsigned int length = static_cast<unsigned>(EVP_MD_size(EVP_sha256()));
   unsigned char* digest = (unsigned char*)OPENSSL_malloc(length);
   if (digest == nullptr) {
     std::cerr << "failed to allocate memory for hash value" << std::endl;
@@ -256,7 +262,7 @@ std::string minio::utils::Sha256Hash(std::string_view str) {
   return hash;
 }
 
-std::string minio::utils::Base64Encode(std::string_view str) {
+std::string Base64Encode(std::string_view str) {
   const auto base64_memory = BIO_new(BIO_s_mem());
   auto base64 = BIO_new(BIO_f_base64());
   base64 = BIO_push(base64, base64_memory);
@@ -273,7 +279,7 @@ std::string minio::utils::Base64Encode(std::string_view str) {
   return base64_encoded;
 }
 
-std::string minio::utils::Md5sumHash(std::string_view str) {
+std::string Md5sumHash(std::string_view str) {
   EVP_MD_CTX* ctx = EVP_MD_CTX_create();
   if (ctx == nullptr) {
     std::cerr << "failed to create EVP_MD_CTX" << std::endl;
@@ -290,8 +296,8 @@ std::string minio::utils::Md5sumHash(std::string_view str) {
     std::terminate();
   }
 
-  unsigned int length = EVP_MD_size(EVP_md5());
-  unsigned char* digest = (unsigned char*)OPENSSL_malloc(length);
+  unsigned int length = static_cast<unsigned>(EVP_MD_size(EVP_md5()));
+  unsigned char* digest = static_cast<unsigned char*>(OPENSSL_malloc(length));
   if (digest == nullptr) {
     std::cerr << "failed to allocate memory for hash value" << std::endl;
     std::terminate();
@@ -308,16 +314,16 @@ std::string minio::utils::Md5sumHash(std::string_view str) {
   std::string hash(reinterpret_cast<const char*>(digest), length);
   OPENSSL_free(digest);
 
-  return minio::utils::Base64Encode(hash);
+  return Base64Encode(hash);
 }
 
-std::string minio::utils::FormatTime(const std::tm& time, const char* format) {
+std::string FormatTime(const std::tm& time, const char* format) {
   char buf[128];
   std::strftime(buf, 128, format, &time);
   return std::string(buf);
 }
 
-std::tm minio::utils::UtcTime::auxLocaltime(const std::time_t& time) {
+std::tm UtcTime::auxLocaltime(const std::time_t& time) {
   std::tm result{};
 #ifdef _WIN32
   localtime_s(&result, &time);
@@ -327,7 +333,7 @@ std::tm minio::utils::UtcTime::auxLocaltime(const std::time_t& time) {
   return result;
 }
 
-minio::utils::UtcTime minio::utils::UtcTime::Now() {
+UtcTime UtcTime::Now() {
   auto usec_now = std::chrono::system_clock::now().time_since_epoch() /
                   std::chrono::microseconds(1);
   auto secs_local = static_cast<time_t>(usec_now / 1000000);
@@ -335,7 +341,7 @@ minio::utils::UtcTime minio::utils::UtcTime::Now() {
   return UtcTime(secs_utc, static_cast<long>(usec_now % 1000000));
 }
 
-void minio::utils::UtcTime::ToLocalTime(std::tm& time) {
+void UtcTime::ToLocalTime(std::tm& time) {
   auto usec_now = std::chrono::system_clock::now().time_since_epoch() /
                   std::chrono::microseconds(1);
   auto secs_local = static_cast<time_t>(usec_now / 1000000);
@@ -344,15 +350,15 @@ void minio::utils::UtcTime::ToLocalTime(std::tm& time) {
   time = auxLocaltime(secs);
 }
 
-std::string minio::utils::UtcTime::ToSignerDate() const {
+std::string UtcTime::ToSignerDate() const {
   return FormatTime(getBrokenDownTime(), "%Y%m%d");
 }
 
-std::string minio::utils::UtcTime::ToAmzDate() const {
+std::string UtcTime::ToAmzDate() const {
   return FormatTime(getBrokenDownTime(), "%Y%m%dT%H%M%SZ");
 }
 
-std::string minio::utils::UtcTime::ToHttpHeaderValue() const {
+std::string UtcTime::ToHttpHeaderValue() const {
   const auto tm = getBrokenDownTime();
   std::stringstream ss;
   ss << WEEK_DAYS[tm.tm_wday] << ", " << FormatTime(tm, "%d ")
@@ -360,8 +366,7 @@ std::string minio::utils::UtcTime::ToHttpHeaderValue() const {
   return ss.str();
 }
 
-minio::utils::UtcTime minio::utils::UtcTime::FromHttpHeaderValue(
-    const char* value) {
+UtcTime UtcTime::FromHttpHeaderValue(const char* value) {
   std::string s(value);
   if (s.size() != 29) return UtcTime();
 
@@ -397,7 +402,7 @@ minio::utils::UtcTime minio::utils::UtcTime::FromHttpHeaderValue(
   return UtcTime(std::mktime(&t));
 }
 
-std::string minio::utils::UtcTime::ToISO8601UTC() const {
+std::string UtcTime::ToISO8601UTC() const {
   char buf[64];
   snprintf(buf, 64, "%03ld", (long int)usecs_);
   std::string usec_str(buf);
@@ -405,7 +410,7 @@ std::string minio::utils::UtcTime::ToISO8601UTC() const {
   return FormatTime(getBrokenDownTime(), "%Y-%m-%dT%H:%M:%S.") + usec_str + "Z";
 }
 
-minio::utils::UtcTime minio::utils::UtcTime::FromISO8601UTC(const char* value) {
+UtcTime UtcTime::FromISO8601UTC(const char* value) {
   std::tm t{};
   char* rv = strptime(value, "%Y-%m-%dT%H:%M:%S", &t);
   std::time_t secs = std::mktime(&t);
@@ -417,7 +422,7 @@ minio::utils::UtcTime minio::utils::UtcTime::FromISO8601UTC(const char* value) {
   return UtcTime(secs, usecs);
 }
 
-int minio::utils::UtcTime::Compare(const UtcTime& rhs) const {
+int UtcTime::Compare(const UtcTime& rhs) const {
   if (secs_ != rhs.secs_) {
     return (secs_ < rhs.secs_) ? -1 : 1;
   }
@@ -427,12 +432,12 @@ int minio::utils::UtcTime::Compare(const UtcTime& rhs) const {
   return 0;
 }
 
-void minio::utils::Multimap::Add(std::string key, std::string value) {
+void Multimap::Add(std::string key, std::string value) {
   map_[key].insert(std::move(value));
   keys_[ToLower(key)].insert(std::move(key));
 }
 
-void minio::utils::Multimap::AddAll(const Multimap& headers) {
+void Multimap::AddAll(const Multimap& headers) {
   auto m = headers.map_;
   for (auto& [key, values] : m) {
     map_[key].insert(values.begin(), values.end());
@@ -440,7 +445,7 @@ void minio::utils::Multimap::AddAll(const Multimap& headers) {
   }
 }
 
-std::list<std::string> minio::utils::Multimap::ToHttpHeaders() const {
+std::list<std::string> Multimap::ToHttpHeaders() const {
   std::list<std::string> headers;
   for (auto& [key, values] : map_) {
     for (auto& value : values) {
@@ -450,7 +455,7 @@ std::list<std::string> minio::utils::Multimap::ToHttpHeaders() const {
   return headers;
 }
 
-std::string minio::utils::Multimap::ToQueryString() const {
+std::string Multimap::ToQueryString() const {
   std::string query_string;
   for (auto& [key, values] : map_) {
     for (auto& value : values) {
@@ -462,11 +467,11 @@ std::string minio::utils::Multimap::ToQueryString() const {
   return query_string;
 }
 
-bool minio::utils::Multimap::Contains(std::string_view key) const {
+bool Multimap::Contains(std::string_view key) const {
   return keys_.find(ToLower(std::string(key))) != keys_.end();
 }
 
-std::list<std::string> minio::utils::Multimap::Get(std::string_view key) const {
+std::list<std::string> Multimap::Get(std::string_view key) const {
   std::list<std::string> result;
 
   if (const auto i = keys_.find(ToLower(std::string(key))); i != keys_.cend()) {
@@ -479,23 +484,23 @@ std::list<std::string> minio::utils::Multimap::Get(std::string_view key) const {
   return result;
 }
 
-std::string minio::utils::Multimap::GetFront(std::string_view key) const {
+std::string Multimap::GetFront(std::string_view key) const {
   std::list<std::string> values = Get(key);
   return (values.size() > 0) ? values.front() : std::string();
 }
 
-std::list<std::string> minio::utils::Multimap::Keys() const {
+std::list<std::string> Multimap::Keys() const {
   std::list<std::string> keys;
   for (const auto& [key, _] : keys_) keys.push_back(key);
   return keys;
 }
 
-void minio::utils::Multimap::GetCanonicalHeaders(
-    std::string& signed_headers, std::string& canonical_headers) const {
+void Multimap::GetCanonicalHeaders(std::string& signed_headers,
+                                   std::string& canonical_headers) const {
   std::vector<std::string> signed_headerslist;
   std::map<std::string, std::string> map;
 
-  for (auto& [k, values] : map_) {
+  for (const auto& [k, values] : map_) {
     std::string key = ToLower(k);
     if ("authorization" == key || "user-agent" == key) continue;
     if (std::find(signed_headerslist.begin(), signed_headerslist.end(), key) ==
@@ -504,7 +509,7 @@ void minio::utils::Multimap::GetCanonicalHeaders(
     }
 
     std::string value;
-    for (auto& v : values) {
+    for (const auto& v : values) {
       if (!value.empty()) value += ",";
       value += std::regex_replace(v, MULTI_SPACE_REGEX, " ");
     }
@@ -524,7 +529,7 @@ void minio::utils::Multimap::GetCanonicalHeaders(
   canonical_headers = utils::Join(canonical_headerslist, "\n");
 }
 
-std::string minio::utils::Multimap::GetCanonicalQueryString() const {
+std::string Multimap::GetCanonicalQueryString() const {
   std::vector<std::string> keys;
   for (auto& [key, _] : map_) {
     keys.push_back(key);
@@ -544,8 +549,7 @@ std::string minio::utils::Multimap::GetCanonicalQueryString() const {
   return utils::Join(values, "&");
 }
 
-minio::error::Error minio::utils::CheckBucketName(std::string_view bucket_name,
-                                                  bool strict) {
+error::Error CheckBucketName(std::string_view bucket_name, bool strict) {
   if (Trim(bucket_name).empty()) {
     return error::Error("bucket name cannot be empty");
   }
@@ -581,16 +585,15 @@ minio::error::Error minio::utils::CheckBucketName(std::string_view bucket_name,
   return error::SUCCESS;
 }
 
-minio::error::Error minio::utils::ReadPart(std::istream& stream, char* buf,
-                                           size_t size, size_t& bytes_read) {
+error::Error ReadPart(std::istream& stream, char* buf, size_t size,
+                      size_t& bytes_read) {
   stream.read(buf, size);
   bytes_read = stream.gcount();
-  return minio::error::SUCCESS;
+  return error::SUCCESS;
 }
 
-minio::error::Error minio::utils::CalcPartInfo(long object_size,
-                                               size_t& part_size,
-                                               long& part_count) {
+error::Error CalcPartInfo(long object_size, size_t& part_size,
+                          long& part_count) {
   if (part_size > 0) {
     if (part_size < kMinPartSize) {
       return error::Error("part size " + std::to_string(part_size) +
@@ -637,14 +640,14 @@ minio::error::Error minio::utils::CalcPartInfo(long object_size,
   return error::SUCCESS;
 }
 
-minio::utils::CharBuffer::~CharBuffer() {}
+CharBuffer::~CharBuffer() {}
 
-std::streambuf::pos_type minio::utils::CharBuffer::seekpos(
-    pos_type sp, std::ios_base::openmode which) {
+std::streambuf::pos_type CharBuffer::seekpos(pos_type sp,
+                                             std::ios_base::openmode which) {
   return seekoff(sp - pos_type(off_type(0)), std::ios_base::beg, which);
 }
 
-std::streambuf::pos_type minio::utils::CharBuffer::seekoff(
+std::streambuf::pos_type CharBuffer::seekoff(
     off_type off, std::ios_base::seekdir dir,
     std::ios_base::openmode /* which */) {
   if (dir == std::ios_base::cur)
@@ -655,3 +658,5 @@ std::streambuf::pos_type minio::utils::CharBuffer::seekoff(
     setg(eback(), eback() + off, egptr());
   return gptr() - eback();
 }
+
+}  // namespace minio::utils


### PR DESCRIPTION
  * use namespace::subnamespace where applicable
  * make minio::error::SUCCESS declared only once
  * make more constructors explicit (minio::error)
  * moved constants that seem private into .cc files
  * added .clang-format file to enforce more formatting rules