### PR TITLE
Enhanced CMakeLists.txt to create a proper export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,10 @@ project(miniocpp
 
 include(GNUInstallDirs)
 include(CheckIncludeFiles)
+include(CMakePackageConfigHelpers)
 
 option(MINIO_CPP_TEST "Build tests" OFF)
 option(MINIO_CPP_MAKE_DOC "Build documentation" OFF)
-
-# TODO: Leftovers from previous CMake build script:
-#set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(MINIO_CPP_CFLAGS)
 set(MINIO_CPP_LIBS)
@@ -58,26 +56,25 @@ endif()
 # Dependencies
 # ------------
 
-find_package(CURL REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(unofficial-curlpp CONFIG REQUIRED)
 find_package(unofficial-inih CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(pugixml CONFIG REQUIRED)
+find_package(ZLIB REQUIRED)
 
 list(APPEND MINIO_CPP_LIBS
-  CURL::libcurl
   unofficial::curlpp::curlpp
   unofficial::inih::inireader
   nlohmann_json::nlohmann_json
   pugixml
   OpenSSL::SSL OpenSSL::Crypto
+  ZLIB::ZLIB
 )
 
 if (WIN32)
   list(APPEND MINIO_CPP_LIBS wsock32)
   list(APPEND MINIO_CPP_LIBS ws2_32)
-  list(APPEND MINIO_CPP_LIBS ZLIB::ZLIB)
 endif()
 
 # Minio C++ Library
@@ -121,9 +118,13 @@ set(MINIO_CPP_HEADERS
 add_library(miniocpp STATIC ${MINIO_CPP_SOURCES} ${MINIO_CPP_HEADERS})
 target_compile_options(miniocpp PRIVATE ${MINIO_CPP_CFLAGS})
 target_compile_features(miniocpp PUBLIC cxx_std_${MINIO_CPP_STD})
-target_include_directories(miniocpp PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(miniocpp PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 set_target_properties(miniocpp PROPERTIES VERSION "${MINIO_CPP_VERSION_STRING}")
+set_target_properties(miniocpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Add a cmake alias - this is how users should use minio-cpp in their cmake projects.
 add_library(miniocpp::miniocpp ALIAS miniocpp)
@@ -227,15 +228,28 @@ endif()
 # Installation Instructions
 # -------------------------
 
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/miniocpp-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/miniocpp-config.cmake"
+  INSTALL_DESTINATION
+    "{CMAKE_INSTALL_LIBDIR}/cmake/miniocpp"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
 install(TARGETS miniocpp
-        EXPORT miniocpp-config
+        EXPORT miniocpp-targets
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-install(EXPORT miniocpp-config
+install(EXPORT miniocpp-targets
         NAMESPACE miniocpp::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp"
+        EXPORT_LINK_INTERFACE_LIBRARIES)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/miniocpp-config.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp")
 
 install(FILES

--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ Typically `minio-cpp` will be part of dependencies specified in `vcpkg.json` fil
 }
 ```
 
+## Using `minio-cpp` with cmake
+
+MinIO C++ cliend SDK can be consumed as a dependency in CMakeLists.txt, the following can be used as an example:
+
+```cmake
+cmake_minimum_required(VERSION 3.10)
+
+project(miniocpp_example LANGUAGES C CXX)
+
+# This will try to find miniocpp package and all its dependencies.
+find_package(miniocpp REQUIRED)
+
+# Create an executable called miniocpp-example:
+add_executable(miniocpp-example example.cpp)
+
+# Link the executable to miniocpp and all its dependencies:
+target_link_libraries(miniocpp-example PRIVATE miniocpp::miniocpp)
+
+# Make sure you are using at least C++17:
+target_compile_features(miniocpp-example PUBLIC cxx_std_17)
+```
+
+Note that `miniocpp::miniocpp` is a cmake imported target, which contains all the instructions necessary to use `minio-cpp` library from your cmake projet file.
+
 ## Hacking minio-cpp
 
 In order to run minio-cpp tests and examples, you can do the following assuming `VCPKG_ROOT` points to a valid `vcpkg` installation:

--- a/configure.sh
+++ b/configure.sh
@@ -3,7 +3,6 @@
 BUILD_OPTIONS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 
 if [ -n "$VCPKG_ROOT" ]; then
-  $VCPKG_ROOT/vcpkg install
   BUILD_OPTIONS="${BUILD_OPTIONS} -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 fi
 

--- a/miniocpp-config.cmake.in
+++ b/miniocpp-config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+find_package(OpenSSL REQUIRED)
+find_package(unofficial-curlpp CONFIG REQUIRED)
+find_package(unofficial-inih CONFIG REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(pugixml CONFIG REQUIRED)
+find_package(ZLIB REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/miniocpp-targets.cmake")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
     { "name": "nlohmann-json" },
     { "name": "openssl" },
     { "name": "pugixml" },
+    { "name": "zlib", "platform": "windows" },
     { "name": "vcpkg-cmake", "host": true },
     { "name": "vcpkg-cmake-config", "host": true }
   ]


### PR DESCRIPTION
At the moment miniocpp-config.cmake specifies dependencies, but when it's actually used by a client it requires that client resolves the dependencies himself - which means that the client would have to use find_package() to find everything that minio-cpp uses.

This fixes the problem. It creates miniocpp-targets.cmake, which is a file generated by cmake, and also creates miniocpp-config.cmake, which adds the required find_package() commands to the cmake and then includes miniocpp-targets.cmake, which provides the targets.

This change finalizes the integration of minio-cpp with both cmake and vcpkg.