### PR TITLE
Fixed a GetObject() function colliding with WinAPI macro

### DIFF
--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -43,6 +43,11 @@
 #include "miniocpp/types.h"
 #include "miniocpp/utils.h"
 
+// We want exactly `minio::s3::BaseClient::GetObject()` symbol and nothing else.
+#if defined(GetObject)
+#undef GetObject
+#endif
+
 namespace minio::s3 {
 
 utils::Multimap GetCommonListObjectsQueryParams(


### PR DESCRIPTION
Fixes https://github.com/minio/minio-cpp/issues/134