### PR TITLE
Replace the filename type of DownloadObjectArgs and UploadObjectArgs

### DIFF
--- a/include/miniocpp/args.h
+++ b/include/miniocpp/args.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <string>
 #include <type_traits>
+#include <filesystem>
 
 #include "error.h"
 #include "http.h"
@@ -192,7 +193,7 @@ using StatObjectArgs = ObjectConditionalReadArgs;
 using RemoveObjectArgs = ObjectVersionArgs;
 
 struct DownloadObjectArgs : public ObjectReadArgs {
-  std::string filename;
+  std::filesystem::path filename;
   bool overwrite;
   http::ProgressFunction progressfunc = nullptr;
   void* progress_userdata = nullptr;
@@ -359,7 +360,7 @@ struct ComposeObjectArgs : public ObjectWriteArgs {
 };  // struct ComposeObjectArgs
 
 struct UploadObjectArgs : public PutObjectBaseArgs {
-  std::string filename;
+  std::filesystem::path filename;
   http::ProgressFunction progressfunc = nullptr;
   void* progress_userdata = nullptr;
 

--- a/include/miniocpp/args.h
+++ b/include/miniocpp/args.h
@@ -18,12 +18,12 @@
 #ifndef MINIO_CPP_ARGS_H_INCLUDED
 #define MINIO_CPP_ARGS_H_INCLUDED
 
+#include <filesystem>
 #include <functional>
 #include <list>
 #include <map>
 #include <string>
 #include <type_traits>
-#include <filesystem>
 
 #include "error.h"
 #include "http.h"

--- a/include/miniocpp/args.h
+++ b/include/miniocpp/args.h
@@ -18,6 +18,7 @@
 #ifndef MINIO_CPP_ARGS_H_INCLUDED
 #define MINIO_CPP_ARGS_H_INCLUDED
 
+#include <filesystem>
 #include <functional>
 #include <list>
 #include <map>
@@ -208,7 +209,7 @@ using StatObjectArgs = ObjectConditionalReadArgs;
 using RemoveObjectArgs = ObjectVersionArgs;
 
 struct DownloadObjectArgs : public ObjectReadArgs {
-  std::string filename;
+  std::filesystem::path filename;
   bool overwrite;
   http::ProgressFunction progressfunc = nullptr;
   void* progress_userdata = nullptr;
@@ -396,7 +397,7 @@ struct ComposeObjectArgs : public ObjectWriteArgs {
 };  // struct ComposeObjectArgs
 
 struct UploadObjectArgs : public PutObjectBaseArgs {
-  std::string filename;
+  std::filesystem::path filename;
   http::ProgressFunction progressfunc = nullptr;
   void* progress_userdata = nullptr;
 

--- a/include/miniocpp/utils.h
+++ b/include/miniocpp/utils.h
@@ -25,6 +25,7 @@
 #endif
 
 #include <ctime>
+#include <filesystem>
 #include <ios>
 #include <list>
 #include <map>
@@ -37,6 +38,17 @@
 #include "error.h"
 
 namespace minio::utils {
+
+// path::u8string() returns std::string in C++17 but std::u8string in C++20;
+// normalize to std::string so callers work under both standards.
+inline std::string PathToUtf8(const std::filesystem::path& p) {
+#ifdef __cpp_lib_char8_t
+  const std::u8string u8 = p.u8string();
+  return std::string(reinterpret_cast<const char*>(u8.data()), u8.size());
+#else
+  return p.u8string();
+#endif
+}
 
 inline constexpr unsigned int kMaxMultipartCount = 10000;        // 10000 parts
 inline constexpr unsigned int kOptPartSize = 64 * 1024 * 1024;   // 64MiB

--- a/src/args.cc
+++ b/src/args.cc
@@ -213,12 +213,12 @@ error::Error DownloadObjectArgs::Validate() const {
   if (error::Error err = ObjectReadArgs::Validate()) {
     return err;
   }
-  if (!utils::CheckNonEmptyString(filename)) {
+  if (!utils::CheckNonEmptyString(filename.u8string())) {
     return error::Error("filename cannot be empty");
   }
 
   if (!overwrite && std::filesystem::exists(filename)) {
-    return error::Error("file " + filename + " already exists");
+    return error::Error("file " + filename.u8string() + " already exists");
   }
 
   return error::SUCCESS;
@@ -415,16 +415,15 @@ error::Error UploadObjectArgs::Validate() {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
-  if (!utils::CheckNonEmptyString(filename)) {
+  if (!utils::CheckNonEmptyString(filename.u8string())) {
     return error::Error("filename cannot be empty");
   }
 
   if (!std::filesystem::exists(filename)) {
-    return error::Error("file " + filename + " does not exist");
+    return error::Error("file " + filename.u8string() + " does not exist");
   }
 
-  std::filesystem::path file_path = filename;
-  size_t obj_size = std::filesystem::file_size(file_path);
+  size_t obj_size = std::filesystem::file_size(filename);
   object_size = static_cast<long>(obj_size);
   return utils::CalcPartInfo(object_size, part_size, part_count);
 }

--- a/src/args.cc
+++ b/src/args.cc
@@ -211,12 +211,21 @@ error::Error DownloadObjectArgs::Validate() const {
   if (error::Error err = ObjectReadArgs::Validate()) {
     return err;
   }
-  if (!utils::CheckNonEmptyString(filename)) {
+  if (!utils::CheckNonEmptyString(utils::PathToUtf8(filename))) {
     return error::Error("filename cannot be empty");
   }
 
-  if (!overwrite && std::filesystem::exists(filename)) {
-    return error::Error("file " + filename + " already exists");
+  if (!overwrite) {
+    std::error_code ec;
+    const bool exists = std::filesystem::exists(filename, ec);
+    if (ec) {
+      return error::Error("unable to check " + utils::PathToUtf8(filename) +
+                          ": " + ec.message());
+    }
+    if (exists) {
+      return error::Error("file " + utils::PathToUtf8(filename) +
+                          " already exists");
+    }
   }
 
   return error::SUCCESS;
@@ -433,16 +442,21 @@ error::Error UploadObjectArgs::Validate() {
   if (error::Error err = ObjectArgs::Validate()) {
     return err;
   }
-  if (!utils::CheckNonEmptyString(filename)) {
+  if (!utils::CheckNonEmptyString(utils::PathToUtf8(filename))) {
     return error::Error("filename cannot be empty");
   }
 
-  if (!std::filesystem::exists(filename)) {
-    return error::Error("file " + filename + " does not exist");
+  std::error_code ec;
+  const std::uintmax_t obj_size = std::filesystem::file_size(filename, ec);
+  if (ec) {
+    if (ec == std::errc::no_such_file_or_directory) {
+      return error::Error("file " + utils::PathToUtf8(filename) +
+                          " does not exist");
+    }
+    return error::Error("unable to stat " + utils::PathToUtf8(filename) + ": " +
+                        ec.message());
   }
-
-  std::filesystem::path file_path = filename;
-  object_size = static_cast<uint64_t>(std::filesystem::file_size(file_path));
+  object_size = static_cast<uint64_t>(obj_size);
   return utils::CalcPartInfo(object_size, part_size, part_count);
 }
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -780,8 +780,9 @@ UploadObjectResponse Client::UploadObject(UploadObjectArgs args) {
   try {
     file.open(args.filename);
   } catch (std::system_error& err) {
-    return error::make<UploadObjectResponse>(
-        "unable to open file " + args.filename.u8string() + "; " + err.code().message());
+    return error::make<UploadObjectResponse>("unable to open file " +
+                                             args.filename.u8string() + "; " +
+                                             err.code().message());
   }
 
   PutObjectArgs po_args(file, args.object_size, 0);

--- a/src/client.cc
+++ b/src/client.cc
@@ -697,12 +697,13 @@ DownloadObjectResponse Client::DownloadObject(DownloadObjectArgs args) {
     etag = resp.etag;
   }
 
-  std::string temp_filename =
-      args.filename + "." + curlpp::escape(etag) + ".part.minio";
+  std::filesystem::path temp_filename = args.filename;
+  temp_filename.concat("." + curlpp::escape(etag) + ".part.minio");
+
   std::ofstream fout(temp_filename, std::ios::trunc | std::ios::out);
   if (!fout.is_open()) {
     return error::make<DownloadObjectResponse>("unable to open file " +
-                                               temp_filename);
+                                               temp_filename.u8string());
   }
 
   std::string region;
@@ -780,7 +781,7 @@ UploadObjectResponse Client::UploadObject(UploadObjectArgs args) {
     file.open(args.filename);
   } catch (std::system_error& err) {
     return error::make<UploadObjectResponse>(
-        "unable to open file " + args.filename + "; " + err.code().message());
+        "unable to open file " + args.filename.u8string() + "; " + err.code().message());
   }
 
   PutObjectArgs po_args(file, args.object_size, 0);

--- a/src/client.cc
+++ b/src/client.cc
@@ -1160,13 +1160,15 @@ Result<DownloadObjectResponse> Client::DownloadObject(DownloadObjectArgs args) {
     etag = resp->etag;
   }
 
-  std::string temp_filename =
-      args.filename + "." + utils::UriEncode(etag) + ".part.minio";
+  // Keep the temporary name a path so non-ASCII names survive on Windows
+  // (ofstream's path overload uses the wide API there).
+  std::filesystem::path temp_filename = args.filename;
+  temp_filename += "." + utils::UriEncode(etag) + ".part.minio";
   std::ofstream fout(temp_filename,
                      std::ios::trunc | std::ios::out | std::ios::binary);
   if (!fout.is_open()) {
-    return error::make<DownloadObjectResponse>("unable to open file " +
-                                               temp_filename);
+    return error::make<DownloadObjectResponse>(
+        "unable to open file " + utils::PathToUtf8(temp_filename));
   }
 
   std::string region;
@@ -1671,8 +1673,9 @@ Result<UploadObjectResponse> Client::UploadObject(UploadObjectArgs args) {
   try {
     file.open(args.filename);
   } catch (std::system_error& err) {
-    return error::make<UploadObjectResponse>(
-        "unable to open file " + args.filename + "; " + err.code().message());
+    return error::make<UploadObjectResponse>("unable to open file " +
+                                             utils::PathToUtf8(args.filename) +
+                                             "; " + err.code().message());
   }
 
   PutObjectArgs po_args(file, args.object_size, 0);


### PR DESCRIPTION
Hi.
I have a problem with the `filename` attribute type of `DownloadObjectArgs` and `UploadObjectArgs`.
The current type is `std::string`, this leads to a file with utf-8 characters in the path that cannot read.
Example path: `G:\\Tuấn Anh\tết.txt`.
So, I suggest replacing `std::string` with `std::filesystem::path`
Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved file path handling for uploads and downloads.
  * Upload and download operations now support filesystem paths directly, including non-ASCII and platform-specific paths.
  * File validation and error messages now present more consistent, accurate path details.
  * Temporary download files are handled more reliably across supported operating systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->