### PR TITLE
Suggestion: Use std::ios::binary flag when opening files for upload

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -777,7 +777,7 @@ UploadObjectResponse Client::UploadObject(UploadObjectArgs args) {
   std::ifstream file;
   file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   try {
-    file.open(args.filename);
+    file.open(args.filename,std::ios::binary);
   } catch (std::system_error& err) {
     return error::make<UploadObjectResponse>(
         "unable to open file " + args.filename + "; " + err.code().message());


### PR DESCRIPTION
Description
The file is currently opened using file.open(args.filename);, which does not include the std::ios::binary flag.
This causes problems when uploading non-text files (e.g., binary files like images or executables).
To properly handle these types of files, it is recommended to open the file using file.open(args.filename, std::ios::binary);

Steps to Reproduce:
up an *.psd file to the oss sever
error in line:https://github.com/minio/minio-cpp/blob/40824d0872861b06965a032a714a8f4f9097fb32/src/utils.cc#L601
OS: Windows 11 22631.4037
Compiler：MSVC 2019 x64