### PR TITLE
GetObject: fix adding additional headers

### DIFF
--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -894,7 +894,7 @@ GetObjectResponse BaseClient::GetObject(GetObjectArgs args) {
   req.userdata = args.userdata;
   req.progressfunc = args.progressfunc;
   req.progress_userdata = args.progress_userdata;
-  if (args.ssec != nullptr) req.headers.AddAll(args.ssec->Headers());
+  req.headers.AddAll(args.Headers());
 
   return GetObjectResponse(Execute(req));
 }


### PR DESCRIPTION
The current implementation of the `BaseClient::GetObject(GetObjectArgs args)` API does not consume the `ObjectConditionalReadArgs::Headers()` method. This results in conditional headers such as `Range` or `If-Unmodified-Since` not being included in the HTTP request. This PR fixes this issue.
