### PR TITLE
Fixed XML construct on BaseClient::RemoveObjects

### DIFF
--- a/include/miniocpp/utils.h
+++ b/include/miniocpp/utils.h
@@ -69,6 +69,9 @@ std::string Trim(std::string_view str, char ch = ' ');
 // whitespaces.
 bool CheckNonEmptyString(std::string_view str);
 
+// Replace all occurrences of pattern with replacement
+void ReplaceAll(std::string& str, std::string_view pattern, std::string_view replacement);
+
 // ToLower converts string to lower case.
 std::string ToLower(const std::string& str);
 

--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -1459,6 +1459,7 @@ RemoveObjectsResponse BaseClient::RemoveObjects(RemoveObjectsApiArgs args) {
   if (args.quiet) ss << "<Quiet>true</Quiet>";
   for (auto& object : args.objects) {
     ss << "<Object>";
+    utils::ReplaceAll(object.name,"&","&amp;");
     ss << "<Key>" << object.name << "</Key>";
     if (!object.version_id.empty()) {
       ss << "<VersionId>" << object.version_id << "</VersionId>";

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -160,7 +160,15 @@ std::string Trim(std::string_view str, char ch) {
 bool CheckNonEmptyString(std::string_view str) {
   return !str.empty() && Trim(str) == str;
 }
-
+void ReplaceAll(std::string& str, std::string_view pattern, std::string_view replacement){
+  size_t start{0};
+  while ((start = str.find(pattern, start)) !=
+         std::string::npos)
+  {
+    str.replace(start, pattern.length(), replacement);
+    start += replacement.length();
+  }
+}
 std::string ToLower(const std::string& str) {
   std::string s(str);
   std::transform(s.begin(), s.end(), s.begin(), ::tolower);


### PR DESCRIPTION
Problem: If the object path contains the '&' ampersand, it will not be escaped when forming an XML request, as required by the [specification](https://www.w3.org/TR/xml/#NT-Reference:~:text=The%20ampersand%20character,lt%3B%20%22%20respectively.).

The playback path:
1. Upload an object containing &
2. Pass this object to std::list<minio::s3::DeleteObject> objects;
3. Call Client::RemoveObjects

A message will be received in response: `unable to do remove objects; MalformedXML: The XML you provided was not well-formed or did not validate against our published schema. (XML syntax error on line 1: invalid character entity &file (no semicolon))` for the `test/test&file` object.

This PR escapes the ampersand using the string `&amp;`.