### PR TITLE
fix DownloadObject: the downloaded file is different from the origina…

### DIFF
--- a/src/client.cc
+++ b/src/client.cc
@@ -699,7 +699,7 @@ DownloadObjectResponse Client::DownloadObject(DownloadObjectArgs args) {
 
   std::string temp_filename =
       args.filename + "." + curlpp::escape(etag) + ".part.minio";
-  std::ofstream fout(temp_filename, std::ios::trunc | std::ios::out);
+  std::ofstream fout(temp_filename, std::ios::trunc | std::ios::out | std::ios::binary);
   if (!fout.is_open()) {
     return error::make<DownloadObjectResponse>("unable to open file " +
                                                temp_filename);


### PR DESCRIPTION
When the file is a binary file, the content of the file downloaded by the DownloadObject function is different from the original file.
