### PR TITLE
perf: replace O(n²) hex-encoding loops with std::to_chars

### DIFF
--- a/src/signer.cc
+++ b/src/signer.cc
@@ -21,6 +21,7 @@
 #include <openssl/hmac.h>
 
 #include <array>
+#include <charconv>
 #include <cstdio>
 #include <string>
 #include <type_traits>
@@ -86,10 +87,15 @@ std::string GetSignature(std::string_view signing_key,
                          std::string_view string_to_sign) {
   std::string hash = HmacHash(signing_key, string_to_sign);
   std::string signature;
-  char buf[3];
+  signature.resize(hash.size() * 2);
+  char* out = signature.data();
   for (std::size_t i = 0, n_size = hash.size(); i < n_size; ++i) {
-    snprintf(buf, 3, "%02x", (unsigned char)hash[i]);
-    signature += buf;
+    auto [ptr, ec] = std::to_chars(out, out + 2, hash[i], 16);
+    if (ptr - out == 1) {
+      out[1] = out[0];
+      out[0] = '0';
+    }
+    out += 2;
   }
   return signature;
 }

--- a/src/signer.cc
+++ b/src/signer.cc
@@ -90,7 +90,8 @@ std::string GetSignature(std::string_view signing_key,
   signature.resize(hash.size() * 2);
   char* out = signature.data();
   for (std::size_t i = 0, n_size = hash.size(); i < n_size; ++i) {
-    auto [ptr, ec] = std::to_chars(out, out + 2, hash[i], 16);
+    auto [ptr, ec] =
+        std::to_chars(out, out + 2, static_cast<unsigned char>(hash[i]), 16);
     if (ptr - out == 1) {
       out[1] = out[0];
       out[0] = '0';

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -17,6 +17,8 @@
 
 #include "miniocpp/utils.h"
 
+#include <charconv>
+
 #include "miniocpp/error.h"
 
 #ifdef _WIN32
@@ -266,10 +268,15 @@ std::string Sha256Hash(std::string_view str) {
   EVP_MD_CTX_destroy(ctx);
 
   std::string hash;
-  char buf[3];
+  hash.resize(length * 2);
+  char* out = hash.data();
   for (unsigned int i = 0; i < length; ++i) {
-    snprintf(buf, 3, "%02x", digest[i]);
-    hash += buf;
+    if (auto [ptr, ec] = std::to_chars(out, out + 2, digest[i], 16);
+        ptr - out == 1) {
+      out[1] = out[0];
+      out[0] = '0';
+    }
+    out += 2;
   }
 
   OPENSSL_free(digest);


### PR DESCRIPTION
perf: replace O(n²) hex-encoding loops with std::to_chars
fix https://github.com/minio/minio-cpp/issues/219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cryptographic routines for signature and hash generation by improving hex-encoding performance and reducing temporary allocations. These changes preserve existing outputs and public interfaces while improving speed and reliability of signing and hashing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->