### PR TITLE
fix: api: replace size_t* sentinel ranges with std::optional<size_t>

### DIFF
--- a/include/miniocpp/args.h
+++ b/include/miniocpp/args.h
@@ -92,8 +92,8 @@ struct ObjectReadArgs : public ObjectVersionArgs {
 };  // struct ObjectReadArgs
 
 struct ObjectConditionalReadArgs : public ObjectReadArgs {
-  size_t* offset = nullptr;
-  size_t* length = nullptr;
+  std::optional<size_t> offset;
+  std::optional<size_t> length;
   std::string match_etag;
   std::string not_match_etag;
   utils::UtcTime modified_since;

--- a/src/args.cc
+++ b/src/args.cc
@@ -91,7 +91,7 @@ utils::Multimap ObjectConditionalReadArgs::Headers() const {
   if (len.has_value() && !off.has_value()) {
     off = 0;
   }
-  
+
   std::string range;
   if (off.has_value()) {
     range = "bytes=" + std::to_string(*off) + "-";

--- a/src/args.cc
+++ b/src/args.cc
@@ -85,18 +85,17 @@ utils::Multimap ObjectWriteArgs::Headers() const {
 }
 
 utils::Multimap ObjectConditionalReadArgs::Headers() const {
-  size_t* off = offset;
-  size_t* len = length;
+  std::optional<size_t> off = offset;
+  std::optional<size_t> len = length;
 
-  size_t zero = 0;
-  if (len != nullptr && off == nullptr) {
-    off = &zero;
+  if (len.has_value() && !off.has_value()) {
+    off = 0;
   }
-
+  
   std::string range;
-  if (off != nullptr) {
+  if (off.has_value()) {
     range = "bytes=" + std::to_string(*off) + "-";
-    if (len != nullptr) {
+    if (len.has_value()) {
       range += std::to_string(*off + *len - 1);
     }
   }
@@ -329,7 +328,7 @@ error::Error CopyObjectArgs::Validate() const {
   if (error::Error err = source.Validate()) {
     return err;
   }
-  if (source.offset != nullptr || source.length != nullptr) {
+  if (source.offset.has_value() || source.length.has_value()) {
     if (metadata_directive != nullptr &&
         *metadata_directive == Directive::kCopy) {
       return error::Error(
@@ -356,13 +355,13 @@ error::Error ComposeSource::BuildHeaders(size_t object_size,
   }
   msg += ": ";
 
-  if (offset != nullptr && *offset >= object_size) {
+  if (offset.has_value() && *offset >= object_size) {
     return error::Error(msg + "offset " + std::to_string(*offset) +
                         " is beyond object size " +
                         std::to_string(object_size));
   }
 
-  if (length != nullptr) {
+  if (length.has_value()) {
     if (*length > object_size) {
       return error::Error(msg + "length " + std::to_string(*length) +
                           " is beyond object size " +
@@ -370,8 +369,8 @@ error::Error ComposeSource::BuildHeaders(size_t object_size,
     }
 
     size_t off = 0;
-    if (offset != nullptr) off = *offset;
-    if ((off + *length) > object_size) {
+    if (offset.has_value()) off = *offset;
+    if (length.has_value() && (off + *length) > object_size) {
       return error::Error(
           msg + "compose size " + std::to_string(off + *length) +
           " is beyond object size " + std::to_string(object_size));

--- a/src/client.cc
+++ b/src/client.cc
@@ -279,9 +279,9 @@ StatObjectResponse Client::CalculatePartCount(
     if (error::Error err = source.BuildHeaders(size, etag)) {
       return StatObjectResponse(err);
     }
-    if (source.length != nullptr) {
+    if (source.length.has_value()) {
       size = *source.length;
-    } else if (source.offset != nullptr) {
+    } else if (source.offset.has_value()) {
       size -= *source.offset;
     }
 
@@ -349,7 +349,8 @@ ComposeObjectResponse Client::ComposeObject(ComposeObjectArgs args,
   }
 
   ComposeSource& source = args.sources.front();
-  if (part_count == 1 && source.offset == nullptr && source.length == nullptr) {
+  if (part_count == 1 && !source.offset.has_value() &&
+      !source.length.has_value()) {
     CopyObjectArgs coargs;
     coargs.extra_headers = args.extra_headers;
     coargs.extra_query_params = args.extra_query_params;
@@ -389,14 +390,14 @@ ComposeObjectResponse Client::ComposeObject(ComposeObjectArgs args,
   std::list<Part> parts;
   for (auto& source : args.sources) {
     size_t size = source.ObjectSize();
-    if (source.length != nullptr) {
+    if (source.length.has_value()) {
       size = *source.length;
-    } else if (source.offset != nullptr) {
+    } else if (source.offset.has_value()) {
       size -= *source.offset;
     }
 
     size_t offset = 0;
-    if (source.offset != nullptr) offset = *source.offset;
+    if (source.offset.has_value()) offset = *source.offset;
 
     utils::Multimap headers;
     headers.AddAll(source.Headers());
@@ -404,11 +405,11 @@ ComposeObjectResponse Client::ComposeObject(ComposeObjectArgs args,
 
     if (size <= utils::kMaxPartSize) {
       part_number++;
-      if (source.length != nullptr) {
+      if (source.length.has_value()) {
         headers.Add("x-amz-copy-source-range",
                     "bytes=" + std::to_string(offset) + "-" +
                         std::to_string(offset + *source.length - 1));
-      } else if (source.offset != nullptr) {
+      } else if (source.offset.has_value()) {
         headers.Add("x-amz-copy-source-range",
                     "bytes=" + std::to_string(offset) + "-" +
                         std::to_string(offset + size - 1));
@@ -785,7 +786,7 @@ CopyObjectResponse Client::CopyObject(CopyObjectArgs args) {
     size = resp.size;
   }
 
-  if (args.source.offset != nullptr || args.source.length != nullptr ||
+  if (args.source.offset.has_value() || args.source.length.has_value() ||
       size > utils::kMaxPartSize) {
     if (args.metadata_directive != nullptr &&
         *args.metadata_directive == Directive::kCopy) {


### PR DESCRIPTION
fix: api: replace size_t* sentinel ranges with std::optional<size_t>
fix https://github.com/minio/minio-cpp/issues/223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal parameter handling was modernized to improve type safety and maintainability. Changes are internal and transparent to users; no API or behavioral changes are expected.
  * No user-facing functional impact; existing integrations and workflows remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->