### PR TITLE
fix: stop uploads hanging forever when the connection drops mid-transfer

### DIFF
--- a/include/miniocpp/http.h
+++ b/include/miniocpp/http.h
@@ -130,6 +130,12 @@ struct Request {
   // defaults. Used by the RDMA control plane to fail fast on a dead NIC so
   // the caller can retry (and pick up the failover NIC on the next attempt)
   // instead of blocking on TCP's default ~75s SYN timeout.
+  //
+  // Note: leaving timeout_secs == 0 still installs a low-speed stall guard
+  // (abort if throughput stays below 1 byte/s for 60s) so a dropped/stalled
+  // connection can't hang the transfer forever. It does not bound a healthy
+  // transfer's total duration. Set timeout_secs > 0 for a hard total timeout
+  // (which replaces the stall guard).
   long connect_timeout_secs = 0;
   long timeout_secs = 0;
 

--- a/src/http.cc
+++ b/src/http.cc
@@ -19,24 +19,24 @@
 
 #include <curl/curl.h>
 
+#include <chrono>
 #include <curlpp/Easy.hpp>
 #include <curlpp/Exception.hpp>
 #include <curlpp/Infos.hpp>
 #include <curlpp/Multi.hpp>
 #include <curlpp/Options.hpp>
 #include <curlpp/cURLpp.hpp>
-#include <chrono>
 #include <exception>
 #include <functional>
 #include <iosfwd>
 #include <iostream>
 #include <list>
 #include <mutex>
-#include <thread>
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <type_traits>
 
 #include "miniocpp/error.h"
@@ -58,7 +58,6 @@ namespace {
 // Abort a transfer that makes no progress for this long. Guards against a
 // connection that drops mid-transfer without a clean close (TCP never RSTs),
 // which would otherwise keep the request alive indefinitely.
-// ponytail: fixed default; promote to a Request field if callers need it tunable.
 constexpr long kStallTimeoutSecs = 60;
 
 // curl_global_init() is documented as not thread-safe and is expensive
@@ -412,7 +411,8 @@ Response Request::execute() {
   curl_easy_setopt(raw_handle, CURLOPT_TCP_KEEPALIVE, 1L);
 
   // Fail a stalled transfer instead of hanging forever. Skipped when the caller
-  // set an explicit total timeout (RDMA control plane) — that already bounds it.
+  // set an explicit total timeout (RDMA control plane) — that already bounds
+  // it.
   if (timeout_secs <= 0) {
     curl_easy_setopt(raw_handle, CURLOPT_LOW_SPEED_LIMIT, 1L);
     curl_easy_setopt(raw_handle, CURLOPT_LOW_SPEED_TIME, kStallTimeoutSecs);
@@ -532,8 +532,8 @@ Response Request::execute() {
     // poll lets libcurl enforce its own timeouts (e.g. the low-speed limit set
     // above) and abort the dead transfer.
     if (maxfd < 0) {
-      // libcurl has no fd to wait on yet; select() with empty sets errors out on
-      // Windows, so just poll again shortly.
+      // libcurl has no fd to wait on yet; select() with empty sets errors out
+      // on Windows, so just poll again shortly.
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     } else {
       timeval timeout{};

--- a/src/http.cc
+++ b/src/http.cc
@@ -19,6 +19,7 @@
 
 #include <curl/curl.h>
 
+#include <cerrno>
 #include <chrono>
 #include <curlpp/Easy.hpp>
 #include <curlpp/Exception.hpp>
@@ -540,6 +541,9 @@ Response Request::execute() {
       timeout.tv_sec = 1;
       timeout.tv_usec = 0;
       if (select(maxfd + 1, &fdread, &fdwrite, &fdexcep, &timeout) < 0) {
+#ifndef _WIN32
+        if (errno == EINTR) continue;  // interrupted by a signal; retry
+#endif
         std::cerr << "select() failed; this should not happen" << std::endl;
         std::terminate();
       }

--- a/src/http.cc
+++ b/src/http.cc
@@ -552,6 +552,17 @@ Response Request::execute() {
     }
   }
 
+  // The loop exits once libcurl has no running transfers left. If the transfer
+  // aborted before delivering a single byte (e.g. the low-speed limit or
+  // connect timeout fired on a dropped/stalled connection), the write callback
+  // never ran, so neither status_code nor error was set. Surface a diagnostic
+  // instead of returning a silently-empty failure.
+  if (response.error.empty() && response.status_code == 0) {
+    response.error =
+        "transfer ended without a response (connection dropped, timed out, or "
+        "was aborted before any data was received)";
+  }
+
   if (progressfunc != nullptr) {
     ProgressFunctionArgs args;
     args.userdata = progress_userdata;

--- a/src/http.cc
+++ b/src/http.cc
@@ -25,12 +25,14 @@
 #include <curlpp/Multi.hpp>
 #include <curlpp/Options.hpp>
 #include <curlpp/cURLpp.hpp>
+#include <chrono>
 #include <exception>
 #include <functional>
 #include <iosfwd>
 #include <iostream>
 #include <list>
 #include <mutex>
+#include <thread>
 #include <ostream>
 #include <sstream>
 #include <stdexcept>
@@ -52,6 +54,12 @@
 namespace minio::http {
 
 namespace {
+
+// Abort a transfer that makes no progress for this long. Guards against a
+// connection that drops mid-transfer without a clean close (TCP never RSTs),
+// which would otherwise keep the request alive indefinitely.
+// ponytail: fixed default; promote to a Request field if callers need it tunable.
+constexpr long kStallTimeoutSecs = 60;
 
 // curl_global_init() is documented as not thread-safe and is expensive
 // (OpenSSL init etc). Run it exactly once per process via a function-local
@@ -403,6 +411,13 @@ Response Request::execute() {
   curl_easy_setopt(raw_handle, CURLOPT_SHARE, GlobalCurlShare());
   curl_easy_setopt(raw_handle, CURLOPT_TCP_KEEPALIVE, 1L);
 
+  // Fail a stalled transfer instead of hanging forever. Skipped when the caller
+  // set an explicit total timeout (RDMA control plane) — that already bounds it.
+  if (timeout_secs <= 0) {
+    curl_easy_setopt(raw_handle, CURLOPT_LOW_SPEED_LIMIT, 1L);
+    curl_easy_setopt(raw_handle, CURLOPT_LOW_SPEED_TIME, kStallTimeoutSecs);
+  }
+
   // Request settings.
   request.setOpt(new curlpp::options::CustomRequest{MethodToString(method)});
   std::string urlstring = url.String();
@@ -503,7 +518,7 @@ Response Request::execute() {
     fd_set fdread{};
     fd_set fdwrite{};
     fd_set fdexcep{};
-    int maxfd = 0;
+    int maxfd = -1;
 
     FD_ZERO(&fdread);
     FD_ZERO(&fdwrite);
@@ -511,9 +526,23 @@ Response Request::execute() {
 
     requests.fdset(&fdread, &fdwrite, &fdexcep, &maxfd);
 
-    if (select(maxfd + 1, &fdread, &fdwrite, &fdexcep, nullptr) < 0) {
-      std::cerr << "select() failed; this should not happen" << std::endl;
-      std::terminate();
+    // Bound the wait so the loop keeps pumping libcurl even when no socket ever
+    // becomes ready — otherwise a dropped/stalled connection blocks select()
+    // forever and this (synchronous) call hangs the calling thread. The bounded
+    // poll lets libcurl enforce its own timeouts (e.g. the low-speed limit set
+    // above) and abort the dead transfer.
+    if (maxfd < 0) {
+      // libcurl has no fd to wait on yet; select() with empty sets errors out on
+      // Windows, so just poll again shortly.
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    } else {
+      timeval timeout{};
+      timeout.tv_sec = 1;
+      timeout.tv_usec = 0;
+      if (select(maxfd + 1, &fdread, &fdwrite, &fdexcep, &timeout) < 0) {
+        std::cerr << "select() failed; this should not happen" << std::endl;
+        std::terminate();
+      }
     }
     while (!requests.perform(&left)) {
     }


### PR DESCRIPTION
The libcurl multi-pump loop called select() with a nullptr timeout (block forever). A connection that drops mid-upload without a clean RST/FIN never makes the socket ready, so select() blocked indefinitely and the synchronous Execute() wedged the calling thread permanently -- no further uploads could run. Normal uploads also had no timeout configured (only the RDMA control plane set one), so libcurl had nothing to enforce even when woken.

- Bound the select() wait to 1s so the loop keeps pumping libcurl.
- Handle maxfd < 0 with a short poll-sleep instead of an invalid select() call (which also errors out / terminates on Windows).
- Set a default low-speed timeout (1 byte/s for 60s) so a stalled transfer aborts with CURLE_OPERATION_TIMEDOUT. Gated on timeout_secs <= 0 to leave the RDMA control plane's explicit timeouts unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scenarios where HTTP requests could hang indefinitely during stalled network transfers. The request now applies a low-speed/no-progress timeout so stalled connections fail gracefully.  
  * Updated the post-transfer socket waiting to use bounded polling rather than potentially unbounded waiting.  
  * Improved failure reporting when a request completes without receiving any response data by returning a clearer diagnostic error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->