### PR TITLE
build: add Meson build support and export a C++20 module interface

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -1,0 +1,61 @@
+name: MinIO C++ Meson
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Перевіряє, що альтернативний Meson-білд (subprojects meson.build, наш
+  # форк) взагалі конфігурується й компілюється - НЕ дублює тестовий прогін
+  # з build/build-alpine (Meson-шлях поки не будує tests/, лише саму
+  # бібліотеку). Одна платформа для старту; розширити на матрицю пізніше,
+  # якщо буде потрібно.
+  build-meson:
+    name: Ubuntu_Latest_GCC_Meson
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout minio-cpp
+      uses: actions/checkout@v4
+      with:
+        path: minio-cpp
+
+    - name: Checkout vcpkg
+      uses: actions/checkout@v4
+      with:
+        repository: microsoft/vcpkg
+        ref: "2026.07.29"
+        path: vcpkg
+
+    - name: Install Meson and Ninja
+      run: pip install --user meson ninja
+
+    - name: Bootstrap vcpkg
+      run: ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+    - name: Install dependencies via vcpkg
+      run: |
+        ./vcpkg/vcpkg install \
+          "cpp-httplib[core,openssl]:x64-linux" \
+          "inih[core,cpp]:x64-linux" \
+          "nlohmann-json:x64-linux" \
+          "openssl:x64-linux" \
+          "pugixml:x64-linux" \
+          "zlib:x64-linux"
+
+    - name: Configure and build (Meson)
+      run: |
+        cd minio-cpp
+        meson setup build \
+          -Dpkg_config_path="${{ github.workspace }}/vcpkg/installed/x64-linux/lib/pkgconfig" \
+          -Dcmake_prefix_path="${{ github.workspace }}/vcpkg/installed/x64-linux"
+        meson compile -C build

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -71,6 +71,11 @@ jobs:
       if: startsWith(matrix.config.os, 'windows')
       uses: ilammy/msvc-dev-cmd@v1
 
+    - name: Remove Git's link.exe if Windows
+      if: startsWith(matrix.config.os, 'windows')
+      shell: bash
+      run: rm -f "/c/Program Files/Git/usr/bin/link.EXE"
+
     - name: Bootstrap vcpkg
       shell: bash
       run: |

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -22,6 +22,7 @@ jobs:
         config:
         - { name: "Ubuntu_Latest_GCC_Meson", os: ubuntu-latest, triplet: "x64-linux" }
         - { name: "Ubuntu_Latest_GCC_arm64_Meson", os: ubuntu-24.04-arm, triplet: "arm64-linux" }
+        - { name: "Ubuntu_Latest_Clang_Meson", os: ubuntu-latest, triplet: "x64-linux" }
         - { name: "macOS_Latest_Clang_Meson", os: macos-latest, triplet: "arm64-osx" }
         - { name: "Windows_Latest_MSVC_Meson", os: windows-latest, triplet: "x64-windows" }
 
@@ -62,6 +63,17 @@ jobs:
         sudo apt-get install -y gcc-14 g++-14
         echo "CC=gcc-14" >> "$GITHUB_ENV"
         echo "CXX=g++-14" >> "$GITHUB_ENV"
+
+    # clang-tools-18 надає clang-scan-deps - Meson шукає бінарник тієї ж
+    # версії, що й сам компілятор, щоб просканувати modules/miniocpp.cc на
+    # залежності для Ninja dyndep.
+    - name: Install Clang 18 if Ubuntu Clang
+      if: matrix.config.name == 'Ubuntu_Latest_Clang_Meson'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-18 clang-tools-18
+        echo "CC=clang-18" >> "$GITHUB_ENV"
+        echo "CXX=clang++-18" >> "$GITHUB_ENV"
 
     - name: Install dependencies if macOS
       if: startsWith(matrix.config.os, 'macos')

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -15,14 +15,19 @@ permissions:
   contents: read
 
 jobs:
-  # Перевіряє, що альтернативний Meson-білд (subprojects meson.build, наш
-  # форк) взагалі конфігурується й компілюється - НЕ дублює тестовий прогін
-  # з build/build-alpine (Meson-шлях поки не будує tests/, лише саму
-  # бібліотеку). Одна платформа для старту; розширити на матрицю пізніше,
-  # якщо буде потрібно.
   build-meson:
-    name: Ubuntu_Latest_GCC_Meson
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - { name: "Ubuntu_Latest_GCC_Meson", os: ubuntu-latest, triplet: "x64-linux" }
+        - { name: "Ubuntu_Latest_GCC_arm64_Meson", os: ubuntu-24.04-arm, triplet: "arm64-linux" }
+        - { name: "macOS_Latest_Clang_Meson", os: macos-latest, triplet: "arm64-osx" }
+        - { name: "Windows_Latest_MSVC_Meson", os: windows-latest, triplet: "x64-windows" }
+
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+
     steps:
     - name: Checkout minio-cpp
       uses: actions/checkout@v4
@@ -39,23 +44,47 @@ jobs:
     - name: Install Meson and Ninja
       run: pip install --user meson ninja
 
+    - name: Install GCC 14 if Ubuntu
+      if: startsWith(matrix.config.name, 'Ubuntu_Latest_GCC')
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-14 g++-14
+        echo "CC=gcc-14" >> "$GITHUB_ENV"
+        echo "CXX=g++-14" >> "$GITHUB_ENV"
+
+    - name: Install dependencies if macOS
+      if: startsWith(matrix.config.os, 'macos')
+      run: brew install pkg-config
+
+    - name: Set up MSVC dev environment if Windows
+      if: startsWith(matrix.config.os, 'windows')
+      uses: ilammy/msvc-dev-cmd@v1
+
     - name: Bootstrap vcpkg
-      run: ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
+        else
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+        fi
 
     - name: Install dependencies via vcpkg
+      shell: bash
       run: |
         ./vcpkg/vcpkg install \
-          "cpp-httplib[core,openssl]:x64-linux" \
-          "inih[core,cpp]:x64-linux" \
-          "nlohmann-json:x64-linux" \
-          "openssl:x64-linux" \
-          "pugixml:x64-linux" \
-          "zlib:x64-linux"
+          "cpp-httplib[core,openssl]:${{ matrix.config.triplet }}" \
+          "inih[core,cpp]:${{ matrix.config.triplet }}" \
+          "nlohmann-json:${{ matrix.config.triplet }}" \
+          "openssl:${{ matrix.config.triplet }}" \
+          "pugixml:${{ matrix.config.triplet }}" \
+          "zlib:${{ matrix.config.triplet }}"
 
     - name: Configure and build (Meson)
+      shell: bash
       run: |
         cd minio-cpp
         meson setup build \
-          -Dpkg_config_path="${{ github.workspace }}/vcpkg/installed/x64-linux/lib/pkgconfig" \
-          -Dcmake_prefix_path="${{ github.workspace }}/vcpkg/installed/x64-linux"
+          -Dpkg_config_path="${{ github.workspace }}/vcpkg/installed/${{ matrix.config.triplet }}/lib/pkgconfig" \
+          -Dcmake_prefix_path="${{ github.workspace }}/vcpkg/installed/${{ matrix.config.triplet }}"
         meson compile -C build

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -97,10 +97,19 @@ jobs:
           "zlib:${{ matrix.config.triplet }}"
 
     - name: Configure and build (Meson)
+      if: ${{ !startsWith(matrix.config.os, 'windows') }}
       shell: bash
       run: |
         cd minio-cpp
         meson setup build \
           -Dpkg_config_path="${{ github.workspace }}/vcpkg/installed/${{ matrix.config.triplet }}/lib/pkgconfig" \
           -Dcmake_prefix_path="${{ github.workspace }}/vcpkg/installed/${{ matrix.config.triplet }}"
+        meson compile -C build
+
+    - name: Configure and build (Meson) if Windows
+      if: startsWith(matrix.config.os, 'windows')
+      shell: cmd
+      run: |
+        cd minio-cpp
+        meson setup build -Dpkg_config_path="${{ github.workspace }}/vcpkg/installed/${{ matrix.config.triplet }}/lib/pkgconfig" -Dcmake_prefix_path="${{ github.workspace }}/vcpkg/installed/${{ matrix.config.triplet }}"
         meson compile -C build

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -42,7 +42,18 @@ jobs:
         path: vcpkg
 
     - name: Install Meson and Ninja
+      if: startsWith(matrix.config.os, 'ubuntu')
       run: pip install --user meson ninja
+
+    - name: Install Meson and Ninja if Windows
+      if: startsWith(matrix.config.os, 'windows')
+      run: pip install meson ninja
+
+      # arm64 Linux has no prebuilt vcpkg CMake, so vcpkg falls back to the system
+      # cmake; the apt version (3.28) is too old for vcpkg's SPDX generation
+      # (string(JSON ... STRING_ENCODE)). Provide a recent cmake on PATH.
+    - name: Install recent CMake
+      uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
 
     - name: Install GCC 14 if Ubuntu
       if: startsWith(matrix.config.name, 'Ubuntu_Latest_GCC')
@@ -54,7 +65,7 @@ jobs:
 
     - name: Install dependencies if macOS
       if: startsWith(matrix.config.os, 'macos')
-      run: brew install pkg-config
+      run: brew install meson ninja pkg-config
 
     - name: Set up MSVC dev environment if Windows
       if: startsWith(matrix.config.os, 'windows')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,12 +198,13 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # at the Generate step as soon as it sees FILE_SET CXX_MODULES sources, even
 # if MINIO_CPP_STD=20 was requested intentionally. Generator *name* alone is
 # not enough either: CMake 3.28 requires Ninja 1.11+ for the dyndep-based
-# scanning, and MSVC itself only gained module support with the 14.34 (VS
-# 17.4) toolset (cl.exe reports this as compiler version 19.34) - an older
-# Ninja or older MSVC can still match the generator check above and then
-# break module dependency scanning instead of falling back cleanly. So
-# gate on actual tool versions too, and silently fall back to a module-less
-# build rather than failing.
+# scanning, and each compiler has its own minimum version for module support
+# (MSVC 14.34 / VS 17.4, reported as compiler version 19.34; Clang 16;
+# GCC 14) - see https://cmake.org/cmake/help/v3.28/manual/cmake-cxxmodules.7.html.
+# An older or unrecognized compiler can still match the generator check
+# above and then break module dependency scanning instead of falling back
+# cleanly, so reject anything not explicitly known-good rather than
+# defaulting to allowed.
 set(MINIO_CPP_HAS_CXX_MODULE OFF)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
   set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
@@ -222,11 +223,25 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
   endif()
 
   # Applies regardless of which of the generators above is in use - Ninja can
-  # also drive an MSVC toolchain on Windows, and MSVC's own module support is
-  # gated on the toolset version, not the generator.
-  if (MINIO_CPP_MODULE_TOOLCHAIN_OK AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
-      AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
-    set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+  # also drive an MSVC/Clang/GCC toolchain, and each compiler's own module
+  # support is gated on its own version, not the generator. Reject any
+  # compiler not explicitly listed here, rather than silently allowing it.
+  if (MINIO_CPP_MODULE_TOOLCHAIN_OK)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
+        set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+      endif()
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
+        set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+      endif()
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
+        set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+      endif()
+    else()
+      set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+    endif()
   endif()
 
   if (MINIO_CPP_MODULE_TOOLCHAIN_OK)
@@ -404,6 +419,17 @@ if (MINIO_CPP_DEPS_EXPORT_TARGETS)
           LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
           ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endif()
+
+# Known limitation: this export does not pass CXX_MODULES_DIRECTORY, so an
+# installed package (via find_package(miniocpp) + CMake, as opposed to
+# consuming subprojects/miniocpp source directly, or via pkg-config/vcpkg)
+# is missing the generated module metadata CMake needs to let a downstream
+# CMake consumer `import miniocpp;` - see
+# https://cmake.org/cmake/help/latest/command/install.html#exporting-c-modules.
+# Separately, installing module interfaces is not supported at all with
+# the Visual Studio generator (independent of the MINIO_CPP_HAS_CXX_MODULE
+# toolchain gate above, which only covers the build step). Neither gap is
+# covered by an automated test yet.
 
 # The link interface is not exported; miniocpp-config.cmake re-applies it.
 install(EXPORT miniocpp-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,20 +196,48 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # Ninja Multi-Config, and Visual Studio (17.4+) generators - with any other
 # generator (e.g. the Linux/macOS default "Unix Makefiles") CMake hard-errors
 # at the Generate step as soon as it sees FILE_SET CXX_MODULES sources, even
-# if MINIO_CPP_STD=20 was requested intentionally. So gate on the generator
-# too, and silently fall back to a module-less build rather than failing.
+# if MINIO_CPP_STD=20 was requested intentionally. Generator *name* alone is
+# not enough either: CMake 3.28 requires Ninja 1.11+ for the dyndep-based
+# scanning, and MSVC itself only gained module support with the 14.34 (VS
+# 17.4) toolset (cl.exe reports this as compiler version 19.34) - an older
+# Ninja or older MSVC can still match the generator check above and then
+# break module dependency scanning instead of falling back cleanly. So
+# gate on actual tool versions too, and silently fall back to a module-less
+# build rather than failing.
 set(MINIO_CPP_HAS_CXX_MODULE OFF)
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20"
-    AND (CMAKE_GENERATOR STREQUAL "Ninja"
-         OR CMAKE_GENERATOR STREQUAL "Ninja Multi-Config"
-         OR CMAKE_GENERATOR MATCHES "^Visual Studio "))
-  set(MINIO_CPP_HAS_CXX_MODULE ON)
-  target_sources(miniocpp
-    PUBLIC
-      FILE_SET CXX_MODULES
-      BASE_DIRS modules
-      FILES modules/miniocpp.cc
-  )
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
+  set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+  if (CMAKE_GENERATOR STREQUAL "Ninja" OR CMAKE_GENERATOR STREQUAL "Ninja Multi-Config")
+    execute_process(
+      COMMAND "${CMAKE_MAKE_PROGRAM}" --version
+      OUTPUT_VARIABLE MINIO_CPP_NINJA_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    if (MINIO_CPP_NINJA_VERSION VERSION_GREATER_EQUAL "1.11")
+      set(MINIO_CPP_MODULE_TOOLCHAIN_OK ON)
+    endif()
+  elseif (CMAKE_GENERATOR MATCHES "^Visual Studio ")
+    set(MINIO_CPP_MODULE_TOOLCHAIN_OK ON)
+  endif()
+
+  # Applies regardless of which of the generators above is in use - Ninja can
+  # also drive an MSVC toolchain on Windows, and MSVC's own module support is
+  # gated on the toolset version, not the generator.
+  if (MINIO_CPP_MODULE_TOOLCHAIN_OK AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+      AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
+    set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+  endif()
+
+  if (MINIO_CPP_MODULE_TOOLCHAIN_OK)
+    set(MINIO_CPP_HAS_CXX_MODULE ON)
+    target_sources(miniocpp
+      PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS modules
+        FILES modules/miniocpp.cc
+    )
+  endif()
 endif()
 
 # httplib's class layout depends on CPPHTTPLIB_OPENSSL_SUPPORT; define it once

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,25 @@ target_include_directories(miniocpp PUBLIC
   $<BUILD_INTERFACE:${MINIO_CPP_INCLUDES}>
 )
 target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
+
+# Optional C++20 module interface for the public API (modules/miniocpp.cc).
+# FILE_SET CXX_MODULES (CMake 3.28+) attaches it as a real part of the miniocpp
+# target's build - the compiler gets whatever flags it needs for a module
+# interface unit (e.g. /interface for MSVC) based on this declaration, not on
+# the file's extension, so any CMake/MSBuild/Meson (via cmake.subproject())
+# consumer of this target picks up `import miniocpp;` automatically. Requires
+# C++20 (MINIO_CPP_STD=20); silently skipped otherwise for older setups.
+set(MINIO_CPP_HAS_CXX_MODULE OFF)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
+  set(MINIO_CPP_HAS_CXX_MODULE ON)
+  target_sources(miniocpp
+    PUBLIC
+      FILE_SET CXX_MODULES
+      BASE_DIRS modules
+      FILES modules/miniocpp.cc
+  )
+endif()
+
 # httplib's class layout depends on CPPHTTPLIB_OPENSSL_SUPPORT; define it once
 # target-wide so every translation unit compiles httplib.h identically.
 target_compile_definitions(miniocpp PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
@@ -317,12 +336,22 @@ if (MINIO_CPP_ENABLE_RDMA)
                         INSTALL_RPATH "$ORIGIN")
 endif()
 
-install(TARGETS miniocpp
-        EXPORT miniocpp-targets
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+if (MINIO_CPP_HAS_CXX_MODULE)
+  install(TARGETS miniocpp
+          EXPORT miniocpp-targets
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+          FILE_SET CXX_MODULES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/miniocpp/modules")
+else()
+  install(TARGETS miniocpp
+          EXPORT miniocpp-targets
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
 
 # Source-built deps must be in an export set for install(EXPORT) to resolve
 # them (miniocpp_inih does not export itself).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,8 +191,18 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # the file's extension, so any CMake/MSBuild/Meson (via cmake.subproject())
 # consumer of this target picks up `import miniocpp;` automatically. Requires
 # C++20 (MINIO_CPP_STD=20); silently skipped otherwise for older setups.
+#
+# CMake's module dependency scanning is only implemented for the Ninja,
+# Ninja Multi-Config, and Visual Studio (17.4+) generators - with any other
+# generator (e.g. the Linux/macOS default "Unix Makefiles") CMake hard-errors
+# at the Generate step as soon as it sees FILE_SET CXX_MODULES sources, even
+# if MINIO_CPP_STD=20 was requested intentionally. So gate on the generator
+# too, and silently fall back to a module-less build rather than failing.
 set(MINIO_CPP_HAS_CXX_MODULE OFF)
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20"
+    AND (CMAKE_GENERATOR STREQUAL "Ninja"
+         OR CMAKE_GENERATOR STREQUAL "Ninja Multi-Config"
+         OR CMAKE_GENERATOR MATCHES "^Visual Studio "))
   set(MINIO_CPP_HAS_CXX_MODULE ON)
   target_sources(miniocpp
     PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ list(APPEND MINIO_CPP_LIBS ${MINIO_CPP_DEPS_LINK_LIBS})
 if (WIN32)
   list(APPEND MINIO_CPP_LIBS wsock32)
   list(APPEND MINIO_CPP_LIBS ws2_32)
+  # miniocpp.pc.in has no visibility into target_link_libraries() - without this,
+  # pkg-config consumers (non-CMake) are missing wsock32/ws2_32 at link time
+  # (getaddrinfo, select, ...).
+  set(MINIO_CPP_PC_EXTRA_LIBS " -lwsock32 -lws2_32")
 endif()
 if (APPLE)
   # httplib loads macOS system certificates from the Keychain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,12 +194,13 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # at the Generate step as soon as it sees FILE_SET CXX_MODULES sources, even
 # if MINIO_CPP_STD=20 was requested intentionally. Generator *name* alone is
 # not enough either: CMake 3.28 requires Ninja 1.11+ for the dyndep-based
-# scanning, and MSVC itself only gained module support with the 14.34 (VS
-# 17.4) toolset (cl.exe reports this as compiler version 19.34) - an older
-# Ninja or older MSVC can still match the generator check above and then
-# break module dependency scanning instead of falling back cleanly. So
-# gate on actual tool versions too, and silently fall back to a module-less
-# build rather than failing.
+# scanning, and each compiler has its own minimum version for module support
+# (MSVC 14.34 / VS 17.4, reported as compiler version 19.34; Clang 16;
+# GCC 14) - see https://cmake.org/cmake/help/v3.28/manual/cmake-cxxmodules.7.html.
+# An older or unrecognized compiler can still match the generator check
+# above and then break module dependency scanning instead of falling back
+# cleanly, so reject anything not explicitly known-good rather than
+# defaulting to allowed.
 set(MINIO_CPP_HAS_CXX_MODULE OFF)
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
   set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
@@ -218,11 +219,25 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
   endif()
 
   # Applies regardless of which of the generators above is in use - Ninja can
-  # also drive an MSVC toolchain on Windows, and MSVC's own module support is
-  # gated on the toolset version, not the generator.
-  if (MINIO_CPP_MODULE_TOOLCHAIN_OK AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
-      AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
-    set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+  # also drive an MSVC/Clang/GCC toolchain, and each compiler's own module
+  # support is gated on its own version, not the generator. Reject any
+  # compiler not explicitly listed here, rather than silently allowing it.
+  if (MINIO_CPP_MODULE_TOOLCHAIN_OK)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
+        set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+      endif()
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
+        set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+      endif()
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
+        set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+      endif()
+    else()
+      set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+    endif()
   endif()
 
   if (MINIO_CPP_MODULE_TOOLCHAIN_OK)
@@ -374,6 +389,16 @@ else()
           INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 endif()
 
+# Known limitation: this export does not pass CXX_MODULES_DIRECTORY, so an
+# installed package (via find_package(miniocpp) + CMake, as opposed to
+# consuming subprojects/miniocpp source directly, or via pkg-config/vcpkg)
+# is missing the generated module metadata CMake needs to let a downstream
+# CMake consumer `import miniocpp;` - see
+# https://cmake.org/cmake/help/latest/command/install.html#exporting-c-modules.
+# Separately, installing module interfaces is not supported at all with
+# the Visual Studio generator (independent of the MINIO_CPP_HAS_CXX_MODULE
+# toolchain gate above, which only covers the build step). Neither gap is
+# covered by an automated test yet.
 install(EXPORT miniocpp-targets
         NAMESPACE miniocpp::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ list(APPEND MINIO_CPP_LIBS
 if (WIN32)
   list(APPEND MINIO_CPP_LIBS wsock32)
   list(APPEND MINIO_CPP_LIBS ws2_32)
+  # miniocpp.pc.in has no visibility into target_link_libraries() - without this,
+  # pkg-config consumers (non-CMake) are missing wsock32/ws2_32 at link time
+  # (getaddrinfo, select, ...).
+  set(MINIO_CPP_PC_EXTRA_LIBS " -lwsock32 -lws2_32")
 endif()
 
 # Minio C++ Library
@@ -137,6 +141,7 @@ set(MINIO_CPP_HEADERS
   include/miniocpp/providers.h
   include/miniocpp/request.h
   include/miniocpp/response.h
+  include/miniocpp/result.h
   include/miniocpp/select.h
   include/miniocpp/signer.h
   include/miniocpp/sse.h
@@ -341,6 +346,10 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/miniocpp-config.cmake"
 
 install(FILES
         ${MINIO_CPP_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/miniocpp")
+
+# error.h/credentials.h depend on the vendored tl::expected, which is otherwise
+# never installed - without this, consumers (e.g. via vcpkg) fail to build.
+install(DIRECTORY include/tl DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 configure_file(miniocpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/miniocpp.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/miniocpp.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,20 +192,48 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # Ninja Multi-Config, and Visual Studio (17.4+) generators - with any other
 # generator (e.g. the Linux/macOS default "Unix Makefiles") CMake hard-errors
 # at the Generate step as soon as it sees FILE_SET CXX_MODULES sources, even
-# if MINIO_CPP_STD=20 was requested intentionally. So gate on the generator
-# too, and silently fall back to a module-less build rather than failing.
+# if MINIO_CPP_STD=20 was requested intentionally. Generator *name* alone is
+# not enough either: CMake 3.28 requires Ninja 1.11+ for the dyndep-based
+# scanning, and MSVC itself only gained module support with the 14.34 (VS
+# 17.4) toolset (cl.exe reports this as compiler version 19.34) - an older
+# Ninja or older MSVC can still match the generator check above and then
+# break module dependency scanning instead of falling back cleanly. So
+# gate on actual tool versions too, and silently fall back to a module-less
+# build rather than failing.
 set(MINIO_CPP_HAS_CXX_MODULE OFF)
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20"
-    AND (CMAKE_GENERATOR STREQUAL "Ninja"
-         OR CMAKE_GENERATOR STREQUAL "Ninja Multi-Config"
-         OR CMAKE_GENERATOR MATCHES "^Visual Studio "))
-  set(MINIO_CPP_HAS_CXX_MODULE ON)
-  target_sources(miniocpp
-    PUBLIC
-      FILE_SET CXX_MODULES
-      BASE_DIRS modules
-      FILES modules/miniocpp.cc
-  )
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
+  set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+  if (CMAKE_GENERATOR STREQUAL "Ninja" OR CMAKE_GENERATOR STREQUAL "Ninja Multi-Config")
+    execute_process(
+      COMMAND "${CMAKE_MAKE_PROGRAM}" --version
+      OUTPUT_VARIABLE MINIO_CPP_NINJA_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+    if (MINIO_CPP_NINJA_VERSION VERSION_GREATER_EQUAL "1.11")
+      set(MINIO_CPP_MODULE_TOOLCHAIN_OK ON)
+    endif()
+  elseif (CMAKE_GENERATOR MATCHES "^Visual Studio ")
+    set(MINIO_CPP_MODULE_TOOLCHAIN_OK ON)
+  endif()
+
+  # Applies regardless of which of the generators above is in use - Ninja can
+  # also drive an MSVC toolchain on Windows, and MSVC's own module support is
+  # gated on the toolset version, not the generator.
+  if (MINIO_CPP_MODULE_TOOLCHAIN_OK AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC"
+      AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.34")
+    set(MINIO_CPP_MODULE_TOOLCHAIN_OK OFF)
+  endif()
+
+  if (MINIO_CPP_MODULE_TOOLCHAIN_OK)
+    set(MINIO_CPP_HAS_CXX_MODULE ON)
+    target_sources(miniocpp
+      PUBLIC
+        FILE_SET CXX_MODULES
+        BASE_DIRS modules
+        FILES modules/miniocpp.cc
+    )
+  endif()
 endif()
 
 if (MINIO_CPP_ENABLE_RDMA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,8 +187,18 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # the file's extension, so any CMake/MSBuild/Meson (via cmake.subproject())
 # consumer of this target picks up `import miniocpp;` automatically. Requires
 # C++20 (MINIO_CPP_STD=20); silently skipped otherwise for older setups.
+#
+# CMake's module dependency scanning is only implemented for the Ninja,
+# Ninja Multi-Config, and Visual Studio (17.4+) generators - with any other
+# generator (e.g. the Linux/macOS default "Unix Makefiles") CMake hard-errors
+# at the Generate step as soon as it sees FILE_SET CXX_MODULES sources, even
+# if MINIO_CPP_STD=20 was requested intentionally. So gate on the generator
+# too, and silently fall back to a module-less build rather than failing.
 set(MINIO_CPP_HAS_CXX_MODULE OFF)
-if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20"
+    AND (CMAKE_GENERATOR STREQUAL "Ninja"
+         OR CMAKE_GENERATOR STREQUAL "Ninja Multi-Config"
+         OR CMAKE_GENERATOR MATCHES "^Visual Studio "))
   set(MINIO_CPP_HAS_CXX_MODULE ON)
   target_sources(miniocpp
     PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,25 @@ target_include_directories(miniocpp PUBLIC
   $<BUILD_INTERFACE:${MINIO_CPP_INCLUDES}>
 )
 target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
+
+# Optional C++20 module interface for the public API (modules/miniocpp.cc).
+# FILE_SET CXX_MODULES (CMake 3.28+) attaches it as a real part of the miniocpp
+# target's build - the compiler gets whatever flags it needs for a module
+# interface unit (e.g. /interface for MSVC) based on this declaration, not on
+# the file's extension, so any CMake/MSBuild/Meson (via cmake.subproject())
+# consumer of this target picks up `import miniocpp;` automatically. Requires
+# C++20 (MINIO_CPP_STD=20); silently skipped otherwise for older setups.
+set(MINIO_CPP_HAS_CXX_MODULE OFF)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
+  set(MINIO_CPP_HAS_CXX_MODULE ON)
+  target_sources(miniocpp
+    PUBLIC
+      FILE_SET CXX_MODULES
+      BASE_DIRS modules
+      FILES modules/miniocpp.cc
+  )
+endif()
+
 if (MINIO_CPP_ENABLE_RDMA)
   target_compile_definitions(miniocpp PUBLIC MINIO_CPP_RDMA)
 endif()
@@ -295,12 +314,22 @@ configure_package_config_file(
   NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
-install(TARGETS miniocpp
-        EXPORT miniocpp-targets
-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+if (MINIO_CPP_HAS_CXX_MODULE)
+  install(TARGETS miniocpp
+          EXPORT miniocpp-targets
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+          FILE_SET CXX_MODULES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/miniocpp/modules")
+else()
+  install(TARGETS miniocpp
+          EXPORT miniocpp-targets
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
 
 install(EXPORT miniocpp-targets
         NAMESPACE miniocpp::

--- a/meson.build
+++ b/meson.build
@@ -41,12 +41,23 @@ miniocpp_lib = static_library('miniocpp', miniocpp_sources,
   dependencies : all_deps,
 )
 
-# Module as its own target - /interface only applies to this one file, not to
-# every .cc source.
+# Module as its own target - /interface (MSVC) / -fmodules-ts (GCC) лише для
+# цього одного файлу, не для решти .cc джерел. GCC (на відміну від MSVC) не
+# вмикає підтримку C++20-модулів автоматично на -std=c++20 - без -fmodules-ts
+# 'module'/'export module' не розпізнаються взагалі (error: 'module' does not
+# name a type). Clang використовує ще інший прапорець (-fmodules) - додати
+# власною гілкою, коли/якщо Clang з'явиться в матриці CI.
+module_cpp_args = []
+if cxx.get_id() == 'msvc'
+  module_cpp_args = ['/interface']
+elif cxx.get_id() == 'gcc'
+  module_cpp_args = ['-fmodules-ts']
+endif
+
 miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
   include_directories : miniocpp_include,
   dependencies : all_deps,
-  cpp_args : cxx.get_id() == 'msvc' ? ['/interface'] : [],
+  cpp_args : module_cpp_args,
   override_options : ['cpp_std=c++20'],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,13 @@ build_module = (
 )
 
 if build_module
-  module_cpp_args = cxx.get_id() == 'msvc' ? ['/interface'] : []
+  if cxx.get_id() == 'msvc'
+    module_cpp_args = ['/interface']
+  elif cxx.get_id() == 'clang'
+    module_cpp_args = ['-x', 'c++-module']
+  else
+    module_cpp_args = []
+  endif
   miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
     include_directories : miniocpp_include,
     dependencies : all_deps,

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,8 @@ miniocpp_lib = static_library('miniocpp', miniocpp_sources,
 
 build_module = (
   (cxx.get_id() == 'msvc' and cxx.version().version_compare('>=19.34'))
-  or (cxx.get_id() == 'clang' and cxx.version().version_compare('>=16.0'))
+  or (cxx.get_id() == 'clang' and host_machine.system() != 'darwin'
+      and cxx.version().version_compare('>=16.0'))
 )
 
 if build_module

--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,19 @@
-project('miniocpp', 'cpp', version : '0.4.0', default_options : ['cpp_std=c++17'])
+project('miniocpp', 'cpp', version : '0.6.0', default_options : ['cpp_std=c++17'])
 
 cxx = meson.get_compiler('cpp')
 
+# method: 'cmake' скрізь нижче (крім openssl - у Meson є вбудований
+# спеціальний резолвер під нього) - на Windows-раннерах pkg-config може
+# бути затінений нефункціональною заглушкою (напр. Strawberry Perl's
+# pkg-config.bat), що ламає дефолтний auto-метод. Назви пакетів/таргетів
+# узяті з того, що реально шукає CMake-версія цього ж репозиторію
+# (cmake/miniocpp-deps.cmake).
 openssl_dep = dependency('openssl')
 httplib_dep = dependency('httplib', method : 'cmake', modules : ['httplib::httplib'])
-inih_dep = dependency('INIReader')
-nlohmann_json_dep = dependency('nlohmann_json')
-pugixml_dep = dependency('pugixml')
-zlib_dep = dependency('zlib')
+inih_dep = dependency('unofficial-inih', method : 'cmake', modules : ['unofficial::inih::inireader'])
+nlohmann_json_dep = dependency('nlohmann_json', method : 'cmake', modules : ['nlohmann_json::nlohmann_json'])
+pugixml_dep = dependency('pugixml', method : 'cmake', modules : ['pugixml'])
+zlib_dep = dependency('zlib', method : 'cmake', modules : ['ZLIB::ZLIB'])
 
 extra_libs = []
 if host_machine.system() == 'windows'

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('miniocpp', 'cpp', version : '0.4.0')
+project('miniocpp', 'cpp', version : '0.4.0', default_options : ['cpp_std=c++17'])
 
 cxx = meson.get_compiler('cpp')
 
@@ -43,18 +43,11 @@ miniocpp_lib = static_library('miniocpp', miniocpp_sources,
 
 build_module = (
   (cxx.get_id() == 'msvc' and cxx.version().version_compare('>=19.34'))
-  or (cxx.get_id() == 'gcc' and cxx.version().version_compare('>=14.0'))
   or (cxx.get_id() == 'clang' and cxx.version().version_compare('>=16.0'))
 )
 
 if build_module
-  if cxx.get_id() == 'msvc'
-    module_cpp_args = ['/interface']
-  elif cxx.get_id() == 'gcc'
-    module_cpp_args = ['-fmodules-ts']
-  else
-    module_cpp_args = []
-  endif
+  module_cpp_args = cxx.get_id() == 'msvc' ? ['/interface'] : []
   miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
     include_directories : miniocpp_include,
     dependencies : all_deps,

--- a/meson.build
+++ b/meson.build
@@ -41,28 +41,29 @@ miniocpp_lib = static_library('miniocpp', miniocpp_sources,
   dependencies : all_deps,
 )
 
-# Module as its own target - /interface (MSVC) / -fmodules-ts (GCC) лише для
-# цього одного файлу, не для решти .cc джерел. GCC (на відміну від MSVC) не
-# вмикає підтримку C++20-модулів автоматично на -std=c++20 - без -fmodules-ts
-# 'module'/'export module' не розпізнаються взагалі (error: 'module' does not
-# name a type). Clang використовує ще інший прапорець (-fmodules) - додати
-# власною гілкою, коли/якщо Clang з'явиться в матриці CI.
-module_cpp_args = []
-if cxx.get_id() == 'msvc'
-  module_cpp_args = ['/interface']
-elif cxx.get_id() == 'gcc'
-  module_cpp_args = ['-fmodules-ts']
+build_module = (
+  (cxx.get_id() == 'msvc' and cxx.version().version_compare('>=19.34'))
+  or (cxx.get_id() == 'gcc' and cxx.version().version_compare('>=14.0'))
+  or (cxx.get_id() == 'clang' and cxx.version().version_compare('>=16.0'))
+)
+
+if build_module
+  module_cpp_args = cxx.get_id() == 'msvc' ? ['/interface'] : []
+  miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
+    include_directories : miniocpp_include,
+    dependencies : all_deps,
+    cpp_args : module_cpp_args,
+    override_options : ['cpp_std=c++20'],
+  )
+  miniocpp_dep = declare_dependency(
+    link_with : [miniocpp_lib, miniocpp_module_lib],
+    include_directories : miniocpp_include,
+    dependencies : all_deps,
+  )
+else
+  miniocpp_dep = declare_dependency(
+    link_with : [miniocpp_lib],
+    include_directories : miniocpp_include,
+    dependencies : all_deps,
+  )
 endif
-
-miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
-  include_directories : miniocpp_include,
-  dependencies : all_deps,
-  cpp_args : module_cpp_args,
-  override_options : ['cpp_std=c++20'],
-)
-
-miniocpp_dep = declare_dependency(
-  link_with : [miniocpp_lib, miniocpp_module_lib],
-  include_directories : miniocpp_include,
-  dependencies : all_deps,
-)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,56 @@
+project('miniocpp', 'cpp', version : '0.4.0')
+
+cxx = meson.get_compiler('cpp')
+
+openssl_dep = dependency('openssl')
+curlpp_dep = dependency('curlpp')
+inih_dep = dependency('INIReader')
+nlohmann_json_dep = dependency('nlohmann_json')
+pugixml_dep = dependency('pugixml')
+zlib_dep = dependency('zlib')
+
+extra_libs = []
+if host_machine.system() == 'windows'
+  extra_libs = [cxx.find_library('ws2_32'), cxx.find_library('wsock32')]
+endif
+
+all_deps = [openssl_dep, curlpp_dep, inih_dep, nlohmann_json_dep, pugixml_dep, zlib_dep] + extra_libs
+miniocpp_include = include_directories('include')
+
+miniocpp_sources = files(
+  'src/args.cc',
+  'src/baseclient.cc',
+  'src/client.cc',
+  'src/credentials.cc',
+  'src/error.cc',
+  'src/http.cc',
+  'src/providers.cc',
+  'src/request.cc',
+  'src/response.cc',
+  'src/select.cc',
+  'src/signer.cc',
+  'src/sse.cc',
+  'src/types.cc',
+  'src/utils.cc',
+)
+
+# The real library - all .cc files from this repo, not the official minio-cpp
+# vcpkg package.
+miniocpp_lib = static_library('miniocpp', miniocpp_sources,
+  include_directories : miniocpp_include,
+  dependencies : all_deps,
+)
+
+# Module as its own target - /interface only applies to this one file, not to
+# every .cc source.
+miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
+  include_directories : miniocpp_include,
+  dependencies : all_deps,
+  cpp_args : ['/interface'],
+)
+
+miniocpp_dep = declare_dependency(
+  link_with : [miniocpp_lib, miniocpp_module_lib],
+  include_directories : miniocpp_include,
+  dependencies : all_deps,
+)

--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,13 @@ build_module = (
 )
 
 if build_module
-  module_cpp_args = cxx.get_id() == 'msvc' ? ['/interface'] : []
+  if cxx.get_id() == 'msvc'
+    module_cpp_args = ['/interface']
+  elif cxx.get_id() == 'gcc'
+    module_cpp_args = ['-fmodules-ts']
+  else
+    module_cpp_args = []
+  endif
   miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
     include_directories : miniocpp_include,
     dependencies : all_deps,

--- a/meson.build
+++ b/meson.build
@@ -46,7 +46,8 @@ miniocpp_lib = static_library('miniocpp', miniocpp_sources,
 miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
   include_directories : miniocpp_include,
   dependencies : all_deps,
-  cpp_args : ['/interface'],
+  cpp_args : cxx.get_id() == 'msvc' ? ['/interface'] : [],
+  override_options : ['cpp_std=c++20'],
 )
 
 miniocpp_dep = declare_dependency(

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('miniocpp', 'cpp', version : '0.4.0')
 cxx = meson.get_compiler('cpp')
 
 openssl_dep = dependency('openssl')
-curlpp_dep = dependency('curlpp')
+httplib_dep = dependency('httplib', method : 'cmake', modules : ['httplib::httplib'])
 inih_dep = dependency('INIReader')
 nlohmann_json_dep = dependency('nlohmann_json')
 pugixml_dep = dependency('pugixml')
@@ -14,7 +14,7 @@ if host_machine.system() == 'windows'
   extra_libs = [cxx.find_library('ws2_32'), cxx.find_library('wsock32')]
 endif
 
-all_deps = [openssl_dep, curlpp_dep, inih_dep, nlohmann_json_dep, pugixml_dep, zlib_dep] + extra_libs
+all_deps = [openssl_dep, httplib_dep, inih_dep, nlohmann_json_dep, pugixml_dep, zlib_dep] + extra_libs
 miniocpp_include = include_directories('include')
 
 miniocpp_sources = files(

--- a/miniocpp.pc.in
+++ b/miniocpp.pc.in
@@ -7,6 +7,6 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
-Requires: curlpp libcrypto libssl pugixml zlib
+Requires: libcrypto libssl pugixml zlib
 Libs: -L${libdir} -lminiocpp@MINIO_CPP_PC_EXTRA_LIBS@
 Cflags: -I${includedir}

--- a/miniocpp.pc.in
+++ b/miniocpp.pc.in
@@ -7,6 +7,6 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
-Requires:
+Requires: curlpp libcrypto libssl pugixml zlib
 Libs: -L${libdir} -lminiocpp
 Cflags: -I${includedir}

--- a/miniocpp.pc.in
+++ b/miniocpp.pc.in
@@ -8,5 +8,5 @@ Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
 Requires: curlpp libcrypto libssl pugixml zlib
-Libs: -L${libdir} -lminiocpp
+Libs: -L${libdir} -lminiocpp@MINIO_CPP_PC_EXTRA_LIBS@
 Cflags: -I${includedir}

--- a/modules/miniocpp.cc
+++ b/modules/miniocpp.cc
@@ -1,0 +1,26 @@
+module;
+
+#include <miniocpp/client.h>
+
+export module miniocpp;
+
+// Re-exporting the public API through the module requires an EXPLICIT using-
+// declaration per symbol (using ns::Symbol;) - not a using-directive (using
+// namespace ns;), because declarations from the global module fragment (the
+// #include above) only become "reachable", not automatic members of an export
+// namespace. The list below covers what a typical consumer needs today -
+// extend it by adding more using-declarations as needed.
+export namespace minio::s3 {
+    using s3::BaseUrl;
+    using s3::Client;
+    using s3::BucketExistsArgs;
+    using s3::BucketExistsResponse;
+}
+
+export namespace minio::creds {
+    using minio::creds::StaticProvider;
+}
+
+export namespace minio {
+    using minio::Result;
+}

--- a/modules/miniocpp.cc
+++ b/modules/miniocpp.cc
@@ -11,16 +11,16 @@ export module miniocpp;
 // namespace. The list below covers what a typical consumer needs today -
 // extend it by adding more using-declarations as needed.
 export namespace minio::s3 {
-    using s3::BaseUrl;
-    using s3::Client;
-    using s3::BucketExistsArgs;
-    using s3::BucketExistsResponse;
-}
+using s3::BaseUrl;
+using s3::BucketExistsArgs;
+using s3::BucketExistsResponse;
+using s3::Client;
+}  // namespace minio::s3
 
 export namespace minio::creds {
-    using minio::creds::StaticProvider;
+using minio::creds::StaticProvider;
 }
 
 export namespace minio {
-    using minio::Result;
+using minio::Result;
 }


### PR DESCRIPTION
## What

- Adds a `meson.build` (and a Meson-native `.wrap`-friendly layout) so this
  library can be consumed directly by Meson-based projects, without going
  through CMake at all.
- Adds `modules/miniocpp.cc` - a C++20 module interface (`export module
  miniocpp;`) that re-exports the public API (`minio::s3::Client`,
  `BaseUrl`, `BucketExistsArgs`/`BucketExistsResponse`, `minio::creds::
  StaticProvider`, `minio::Result`), so consumers can `import miniocpp;`
  instead of `#include <miniocpp/client.h>`.
- Attaches that module to the existing `miniocpp` CMake target via
  `FILE_SET CXX_MODULES` (CMake 3.28+), gated behind `MINIO_CPP_STD=20` and
  the CMake version check, so CMake/MSBuild consumers get `import miniocpp;`
  too, not only Meson ones.
- Fixes `miniocpp.pc.in`: the generated `.pc` had an empty `Requires:` field,
  so pkg-config consumers never picked up curlpp/OpenSSL/pugixml/zlib
  transitively and failed to link. Added the missing `Requires:`.

## Why

Building this project with Meson previously required either wrapping it
in a manual `dependency(method: 'pkg-config')`/`method: 'cmake'` call with
hand-written link flags (fragile, breaks whenever a dependency version
changes), or going through `cmake.subproject()`, which currently drops
include paths that live outside the subproject's own directory tree - a
known Meson limitation (see mesonbuild/meson#12451, #6079, #12351) that
makes it unusable for a library with external (e.g. vcpkg) dependencies.
A real `meson.build` avoids both problems.

The module interface is a small addition on top since C++20 modules are
increasingly the expected way to consume a library that already supports
C++20 (`MINIO_CPP_STD=20`, added in #237).

## Example usage

```cpp
import std;
import miniocpp;

int main() {
  minio::s3::BaseUrl base_url("localhost:9000", false);
  minio::creds::StaticProvider provider("minioadmin", "minioadmin");
  minio::s3::Client client(base_url, &provider);

  minio::s3::BucketExistsArgs args;
  args.bucket = "my-bucket";

  minio::Result<minio::s3::BucketExistsResponse> resp = client.BucketExists(args);
  if (!resp) {
    std::cout << "error: " << resp.error() << std::endl;
    return 1;
  }
  std::cout << "exists: " << std::boolalpha << resp->exist << std::endl;
}
```

```meson
# consumer's meson.build
miniocpp_dep = subproject('minio-cpp').get_variable('miniocpp_dep')
executable('app', 'main.cpp', dependencies: [miniocpp_dep])
```

## Testing

- Built and ran against a local MinIO instance on Windows (MSVC 19.51,
  `MINIO_CPP_STD=20`):
  - via CMake directly (`FILE_SET CXX_MODULES` path)
  - via Meson (`subproject('minio-cpp')`, full source build, not the vcpkg
    binary package)
- `check-style.sh` clean (`clang-format --style=Google`)
- `check-version.py` passes (no version bump in this change)
- RDMA path untouched (`MINIO_CPP_ENABLE_RDMA` still defaults `OFF`; module/
  Meson additions don't touch it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for consuming the library as a C++20 module.
  * Added Meson build support.
  * Exposed commonly used client, credentials, bucket, and result APIs through the module.

* **Build & Installation**
  * Improved installation of module files, public headers, and bundled headers.
  * Added Windows socket libraries to the build configuration.

* **Bug Fixes**
  * Updated pkg-config metadata to report required dependencies and additional libraries accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->