### PR TITLE
fix cmake build warnings

### DIFF
--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -131,7 +131,7 @@ void BaseClient::HandleRedirectResponse(std::string& code, std::string& message,
 }
 
 Result<Response> BaseClient::GetErrorResponse(http::Response resp,
-                                              std::string_view resource,
+                                              std::string_view,
                                               http::Method method,
                                               const std::string& bucket_name,
                                               const std::string& object_name) {

--- a/src/client.cc
+++ b/src/client.cc
@@ -269,7 +269,7 @@ struct ScopedRDMARegistration {
 
 }  // namespace
 
-ListObjectsResult::ListObjectsResult(error::Error err) : failed_(true) {
+ListObjectsResult::ListObjectsResult(error::Error) : failed_(true) {
   resp_ = std::make_shared<ListObjectsResponse>();
   itr_ = resp_->contents.end();
 }
@@ -384,7 +384,7 @@ void ListObjectsResult::Populate() {
   }
 }
 
-RemoveObjectsResult::RemoveObjectsResult(error::Error err) {
+RemoveObjectsResult::RemoveObjectsResult(error::Error) {
   done_ = true;
   itr_ = resp_.errors.end();
 }
@@ -1023,7 +1023,10 @@ Result<ComposeObjectResponse> Client::ComposeObject(ComposeObjectArgs args) {
     amu_args.region = args.region;
     amu_args.object = args.object;
     amu_args.upload_id = upload_id;
-    AbortMultipartUpload(amu_args);
+    if (auto amu_resp = AbortMultipartUpload(amu_args); !amu_resp) {
+      std::cerr << "warning: unable to abort multipart upload: "
+                << amu_resp.error().String() << std::endl;
+    }
   }
 
   return resp;
@@ -1586,7 +1589,10 @@ Result<PutObjectResponse> Client::PutObject(PutObjectArgs args) {
         amu_args.region = std::move(args.region);
         amu_args.object = std::move(args.object);
         amu_args.upload_id = upload_id;
-        AbortMultipartUpload(amu_args);
+        if (auto amu_resp = AbortMultipartUpload(amu_args); !amu_resp) {
+          std::cerr << "warning: unable to abort multipart upload: "
+                    << amu_resp.error().String() << std::endl;
+        }
       }
       return tl::make_unexpected(first_err);
     }
@@ -1611,7 +1617,10 @@ Result<PutObjectResponse> Client::PutObject(PutObjectArgs args) {
       amu_args.region = std::move(args.region);
       amu_args.object = std::move(args.object);
       amu_args.upload_id = upload_id;
-      AbortMultipartUpload(amu_args);
+      if (auto amu_resp = AbortMultipartUpload(amu_args); !amu_resp) {
+        std::cerr << "warning: unable to abort multipart upload: "
+                  << amu_resp.error().String() << std::endl;
+      }
     }
     if (!cmu_resp) {
       return tl::make_unexpected(cmu_resp.error());
@@ -1658,7 +1667,10 @@ Result<PutObjectResponse> Client::PutObject(PutObjectArgs args) {
     amu_args.region = std::move(args.region);
     amu_args.object = std::move(args.object);
     amu_args.upload_id = upload_id;
-    AbortMultipartUpload(amu_args);
+    if (auto amu_resp = AbortMultipartUpload(amu_args); !amu_resp) {
+      std::cerr << "warning: unable to abort multipart upload: "
+                << amu_resp.error().String() << std::endl;
+    }
   }
 
   return resp;

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -798,7 +798,10 @@ class Tests {
         try {
           minio::s3::RemoveBucketArgs args;
           args.bucket = b;
-          client_.RemoveBucket(args);
+          if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+            std::cout << "warning: unable to remove bucket " << b << ": "
+                      << rm_resp.error().String() << std::endl;
+          }
         } catch (...) {
         }
       };
@@ -1101,7 +1104,10 @@ class Tests {
       } catch (const std::runtime_error&) {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+          std::cout << "warning: unable to remove bucket " << bucket_name
+                    << ": " << rm_resp.error().String() << std::endl;
+        }
         throw;
       }
     }
@@ -1243,7 +1249,10 @@ class Tests {
       } catch (const std::runtime_error&) {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+          std::cout << "warning: unable to remove bucket " << bucket_name
+                    << ": " << rm_resp.error().String() << std::endl;
+        }
         throw;
       }
     }
@@ -1296,7 +1305,10 @@ class Tests {
           try {
             minio::s3::RemoveBucketArgs args;
             args.bucket = b;
-            client_.RemoveBucket(args);
+            if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+              std::cout << "warning: unable to remove bucket " << b << ": "
+                        << rm_resp.error().String() << std::endl;
+            }
           } catch (...) {
           }
         }
@@ -1371,7 +1383,10 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+          std::cout << "warning: unable to remove bucket " << bucket_name
+                    << ": " << rm_resp.error().String() << std::endl;
+        }
       }
     }
 
@@ -1405,7 +1420,10 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+          std::cout << "warning: unable to remove bucket " << bucket_name
+                    << ": " << rm_resp.error().String() << std::endl;
+        }
       }
     }
 
@@ -1439,7 +1457,10 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+          std::cout << "warning: unable to remove bucket " << bucket_name
+                    << ": " << rm_resp.error().String() << std::endl;
+        }
       }
     }
 
@@ -1473,7 +1494,10 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        if (auto rm_resp = client_.RemoveBucket(args); !rm_resp) {
+          std::cout << "warning: unable to remove bucket " << bucket_name
+                    << ": " << rm_resp.error().String() << std::endl;
+        }
       }
     }
 


### PR DESCRIPTION
fix warnings
fix https://github.com/minio/minio-cpp/issues/130
now:
```shell
cmake --build /home/jiuker/GolandProjects/minio-cpp/build --target tests
[  6%] Building CXX object CMakeFiles/miniocpp.dir/src/args.cc.o
[ 13%] Building CXX object CMakeFiles/miniocpp.dir/src/baseclient.cc.o
[ 20%] Building CXX object CMakeFiles/miniocpp.dir/src/client.cc.o
[ 26%] Building CXX object CMakeFiles/miniocpp.dir/src/credentials.cc.o
[ 26%] Building CXX object CMakeFiles/miniocpp.dir/src/error.cc.o
[ 33%] Building CXX object CMakeFiles/miniocpp.dir/src/http.cc.o
[ 40%] Building CXX object CMakeFiles/miniocpp.dir/src/providers.cc.o
[ 46%] Building CXX object CMakeFiles/miniocpp.dir/src/request.cc.o
[ 53%] Building CXX object CMakeFiles/miniocpp.dir/src/response.cc.o
[ 60%] Building CXX object CMakeFiles/miniocpp.dir/src/select.cc.o
[ 60%] Building CXX object CMakeFiles/miniocpp.dir/src/signer.cc.o
[ 66%] Building CXX object CMakeFiles/miniocpp.dir/src/sse.cc.o
[ 73%] Building CXX object CMakeFiles/miniocpp.dir/src/types.cc.o
[ 80%] Building CXX object CMakeFiles/miniocpp.dir/src/utils.cc.o
[ 86%] Linking CXX static library libminiocpp.a
[ 86%] Built target miniocpp
[ 93%] Building CXX object CMakeFiles/tests.dir/tests/tests.cc.o
[100%] Linking CXX executable tests
[100%] Built target tests
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart-upload cleanup by detecting failures and recording warning messages.
  * Improved asynchronous cleanup handling by reporting failed bucket-removal operations.
* **Refactor**
  * Removed unused parameter names from internal error-handling declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->