### PR TITLE
fix: set default false for statObject's deletemarker

### DIFF
--- a/include/miniocpp/response.h
+++ b/include/miniocpp/response.h
@@ -196,7 +196,7 @@ struct StatObjectResponse : public Response {
   RetentionMode retention_mode;
   utils::UtcTime retention_retain_until_date;
   LegalHold legal_hold;
-  bool delete_marker;
+  bool delete_marker = false;
   utils::Multimap user_metadata;
 
   StatObjectResponse() = default;
@@ -284,7 +284,7 @@ MINIO_S3_DERIVE_FROM_PUT_OBJECT_RESPONSE(UploadObjectResponse)
 struct DeletedObject : public Response {
   std::string name;
   std::string version_id;
-  bool delete_marker;
+  bool delete_marker = false;
   std::string delete_marker_version_id;
 
   DeletedObject() = default;

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -301,6 +301,9 @@ class Tests {
             "StatObject(): expected: " + std::to_string(data.length()) +
             "; got: " + std::to_string(resp->size));
       }
+      if (resp->delete_marker) {
+        throw std::runtime_error("StatObject(): expected: false; got: true");
+      }
       RemoveObject(bucket_name_, object_name);
     } catch (const std::runtime_error&) {
       RemoveObject(bucket_name_, object_name);


### PR DESCRIPTION
fix: set default false for statObject's deletemarker
fix https://github.com/minio/minio-cpp/issues/195

can be read to `true` for `Undefined Behavior`