### PR TITLE
fix: prevent false port parsing when host has no colon

### DIFF
--- a/src/http.cc
+++ b/src/http.cc
@@ -208,7 +208,7 @@ Url Url::Parse(std::string value) {
       std::string portstr;
       while (std::getline(ss, portstr, ':')) {
       }
-      
+
       if (host.find(':') != std::string::npos && !portstr.empty()) {
         try {
           port = static_cast<unsigned>(std::stoi(portstr));

--- a/src/http.cc
+++ b/src/http.cc
@@ -19,6 +19,7 @@
 
 #include <curl/curl.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <chrono>
 #include <curlpp/Easy.hpp>
@@ -207,8 +208,8 @@ Url Url::Parse(std::string value) {
       std::string portstr;
       while (std::getline(ss, portstr, ':')) {
       }
-
-      if (!portstr.empty()) {
+      
+      if (host.find(':') != std::string::npos && !portstr.empty()) {
         try {
           port = static_cast<unsigned>(std::stoi(portstr));
           host = host.substr(0, host.rfind(":" + portstr));

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1555,7 +1555,7 @@ void TestUrlParse() noexcept(false) {
       {"10.0.0.1", "10.0.0.1", 0},
       {"example.com", "example.com", 0},
       {"example.com:8080", "example.com", 8080},
-      {"10.0.0.1:9000", "10.0.0.1", 9000},
+      {"10.0.0.1:9000", "10.0.0.1", 9001},
   }};
 
   for (const auto& c : cases) {
@@ -1571,7 +1571,12 @@ void TestUrlParse() noexcept(false) {
 
 int main(int /*argc*/, char* /*argv*/[]) {
   // Unit check first so a parsing regression fails fast without a server.
-  TestUrlParse();
+  try {
+    TestUrlParse();
+  } catch (const std::runtime_error& e) {
+    std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
 
   std::string host;
   if (!minio::utils::GetEnv(host, "SERVER_ENDPOINT")) {

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1539,7 +1539,40 @@ class Tests {
   }  // TestAsyncOperations
 };  // class Tests
 
+// Regression test for the host/port parsing guard in http::Url::Parse():
+// bare IPv4/hostname keep the whole string as host with port 0; only an
+// explicit ":port" suffix is split off.
+void TestUrlParse() noexcept(false) {
+  std::cout << "TestUrlParse()" << std::endl;
+
+  struct UrlParseCase {
+    std::string input;
+    std::string host;
+    unsigned int port;
+  };
+
+  const std::array<UrlParseCase, 4> cases = {{
+      {"10.0.0.1", "10.0.0.1", 0},
+      {"example.com", "example.com", 0},
+      {"example.com:8080", "example.com", 8080},
+      {"10.0.0.1:9000", "10.0.0.1", 9000},
+  }};
+
+  for (const auto& c : cases) {
+    const minio::http::Url url = minio::http::Url::Parse(c.input);
+    if (url.host != c.host || url.port != c.port) {
+      throw std::runtime_error(
+          "TestUrlParse(): Url::Parse(\"" + c.input + "\"): expected host='" +
+          c.host + "' port=" + std::to_string(c.port) + "; got host='" +
+          url.host + "' port=" + std::to_string(url.port));
+    }
+  }
+}
+
 int main(int /*argc*/, char* /*argv*/[]) {
+  // Unit check first so a parsing regression fails fast without a server.
+  TestUrlParse();
+
   std::string host;
   if (!minio::utils::GetEnv(host, "SERVER_ENDPOINT")) {
     std::cerr << "SERVER_ENDPOINT environment variable must be set"

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -1555,7 +1555,7 @@ void TestUrlParse() noexcept(false) {
       {"10.0.0.1", "10.0.0.1", 0},
       {"example.com", "example.com", 0},
       {"example.com:8080", "example.com", 8080},
-      {"10.0.0.1:9000", "10.0.0.1", 9001},
+      {"10.0.0.1:9000", "10.0.0.1", 9000},
   }};
 
   for (const auto& c : cases) {


### PR DESCRIPTION
When the host string contains no colon, std::getline(ss, portstr, ':') assigns the entire host to portstr, causing stoi to silently parse a bogus port number (e.g. "1.2.3.4" → port=1). Add a host.find(':') != npos guard so that port parsing only occurs when a colon is actually present.

fix https://github.com/minio/minio-cpp/issues/203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL parsing to extract port numbers only when a valid port separator and non-empty port value are present.
  * Prevented invalid or empty port values from being accepted.
  * Improved handling of URLs with and without explicitly specified ports across IPv4 addresses and hostnames.
  * Added validation to help ensure port values are interpreted consistently and accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->