### PR TITLE
build: silence -Wextra warnings across the library, tests and examples

### DIFF
--- a/src/baseclient.cc
+++ b/src/baseclient.cc
@@ -130,11 +130,10 @@ void BaseClient::HandleRedirectResponse(std::string& code, std::string& message,
   }
 }
 
-Result<Response> BaseClient::GetErrorResponse(http::Response resp,
-                                              std::string_view resource,
-                                              http::Method method,
-                                              const std::string& bucket_name,
-                                              const std::string& object_name) {
+Result<Response> BaseClient::GetErrorResponse(
+    http::Response resp, [[maybe_unused]] std::string_view resource,
+    http::Method method, const std::string& bucket_name,
+    const std::string& object_name) {
   if (!resp.error.empty()) {
     return tl::make_unexpected(error::Error(resp.error));
   }

--- a/src/client.cc
+++ b/src/client.cc
@@ -269,7 +269,8 @@ struct ScopedRDMARegistration {
 
 }  // namespace
 
-ListObjectsResult::ListObjectsResult(error::Error err) : failed_(true) {
+ListObjectsResult::ListObjectsResult([[maybe_unused]] error::Error err)
+    : failed_(true) {
   resp_ = std::make_shared<ListObjectsResponse>();
   itr_ = resp_->contents.end();
 }
@@ -384,7 +385,7 @@ void ListObjectsResult::Populate() {
   }
 }
 
-RemoveObjectsResult::RemoveObjectsResult(error::Error err) {
+RemoveObjectsResult::RemoveObjectsResult([[maybe_unused]] error::Error err) {
   done_ = true;
   itr_ = resp_.errors.end();
 }
@@ -1023,7 +1024,7 @@ Result<ComposeObjectResponse> Client::ComposeObject(ComposeObjectArgs args) {
     amu_args.region = args.region;
     amu_args.object = args.object;
     amu_args.upload_id = upload_id;
-    AbortMultipartUpload(amu_args);
+    (void)AbortMultipartUpload(amu_args);
   }
 
   return resp;
@@ -1586,7 +1587,7 @@ Result<PutObjectResponse> Client::PutObject(PutObjectArgs args) {
         amu_args.region = std::move(args.region);
         amu_args.object = std::move(args.object);
         amu_args.upload_id = upload_id;
-        AbortMultipartUpload(amu_args);
+        (void)AbortMultipartUpload(amu_args);
       }
       return tl::make_unexpected(first_err);
     }
@@ -1611,7 +1612,7 @@ Result<PutObjectResponse> Client::PutObject(PutObjectArgs args) {
       amu_args.region = std::move(args.region);
       amu_args.object = std::move(args.object);
       amu_args.upload_id = upload_id;
-      AbortMultipartUpload(amu_args);
+      (void)AbortMultipartUpload(amu_args);
     }
     if (!cmu_resp) {
       return tl::make_unexpected(cmu_resp.error());
@@ -1658,7 +1659,7 @@ Result<PutObjectResponse> Client::PutObject(PutObjectArgs args) {
     amu_args.region = std::move(args.region);
     amu_args.object = std::move(args.object);
     amu_args.upload_id = upload_id;
-    AbortMultipartUpload(amu_args);
+    (void)AbortMultipartUpload(amu_args);
   }
 
   return resp;

--- a/tests/tests.cc
+++ b/tests/tests.cc
@@ -798,7 +798,7 @@ class Tests {
         try {
           minio::s3::RemoveBucketArgs args;
           args.bucket = b;
-          client_.RemoveBucket(args);
+          (void)client_.RemoveBucket(args);
         } catch (...) {
         }
       };
@@ -1101,7 +1101,7 @@ class Tests {
       } catch (const std::runtime_error&) {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        (void)client_.RemoveBucket(args);
         throw;
       }
     }
@@ -1243,7 +1243,7 @@ class Tests {
       } catch (const std::runtime_error&) {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        (void)client_.RemoveBucket(args);
         throw;
       }
     }
@@ -1296,7 +1296,7 @@ class Tests {
           try {
             minio::s3::RemoveBucketArgs args;
             args.bucket = b;
-            client_.RemoveBucket(args);
+            (void)client_.RemoveBucket(args);
           } catch (...) {
           }
         }
@@ -1371,7 +1371,7 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        (void)client_.RemoveBucket(args);
       }
     }
 
@@ -1405,7 +1405,7 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        (void)client_.RemoveBucket(args);
       }
     }
 
@@ -1439,7 +1439,7 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        (void)client_.RemoveBucket(args);
       }
     }
 
@@ -1473,7 +1473,7 @@ class Tests {
       {
         minio::s3::RemoveBucketArgs args;
         args.bucket = bucket_name;
-        client_.RemoveBucket(args);
+        (void)client_.RemoveBucket(args);
       }
     }
 


### PR DESCRIPTION
`-Wall -Wextra -Wconversion` are unconditional in `CMakeLists.txt`, and the tree currently emits 15 warnings (7 in the library, 8 in the tests). This clears all of them.

## Changes

- **`src/client.cc`** — the four best-effort `AbortMultipartUpload(amu_args)` cleanup calls on failure paths now discard their `[[nodiscard]]` `Result` explicitly with `(void)`, matching existing precedent in `http.cc:71` and `response.cc:615`.
- **`tests/tests.cc`** — same treatment for the 8 `client_.RemoveBucket(args)` cleanup calls.
- **`src/client.cc`** — the two error-carrying `ListObjectsResult` / `RemoveObjectsResult` constructors take `[[maybe_unused]] error::Error err`.
- **`src/baseclient.cc`** — `GetErrorResponse`'s unused `resource` parameter takes `[[maybe_unused]]`. The signature is left intact: `BaseClient::GetErrorResponse` is public and reachable from downstream C glue.

Touched files were run through `clang-format`.

## Verification

Warning counts with `-Wall -Wextra -Wconversion`, GCC 14.2.0 on Linux/x86_64:

| Configuration | Warnings |
| --- | --- |
| C++17 Release — library + tests + examples | 0 |
| C++20 Release (`MINIO_CPP_STD=20`) — all targets | 0 |
| `MINIO_CPP_ENABLE_RDMA=ON` Release — all targets, incl. `src/c_api.cc` | 0 |
| Debug | 0 across 63 translation units (linking not completed locally — out of disk, unrelated to these changes) |

## Follow-up, not addressed here

`[[maybe_unused]]` on the two result constructors silences the warning but does not restore the dropped error. 3d21189 removed the lines that carried it:

- `ListObjectsResult`: `resp_->contents.push_back(Item(std::move(err)))`
- `RemoveObjectsResult`: `resp_.errors.push_back(DeleteError(err))`

So `ListObjects` with an invalid argument is now indistinguishable from an empty bucket. This is not only the validate path — `StartPrefetch` catches every exception and returns an empty `ListObjectsResponse`, and `Populate` sets `failed_ = true` either way, so a 403 or a network failure looks identical too.

That means a simple `GetError()` accessor fed only from the validate constructor would be worse than none — it would authoritatively report "no error" for a 403. A real fix needs an error channel out of the prefetch future, which changes the type at `client.h:44-45`. Left for a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling of intentionally unused results and parameters.
  * No user-visible behavior or error-handling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->