### PR TITLE
fix: ship prebuilt release bundles incl. arm64 (fixes #212)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,10 @@ jobs:
 
     steps:
     # Manual dispatch: the tag must exist and be a version tag; the build and
-    # the release job (contents: write) depend on it.
+    # the release job (contents: write) depend on it. Resolve it to its peeled
+    # commit so the checkout below builds that exact commit.
     - name: Validate release tag
+      id: validate
       shell: bash
       env:
         RELEASE_TAG: ${{ inputs.tag }}
@@ -63,19 +65,25 @@ jobs:
               exit 1
               ;;
           esac
-          if ! git ls-remote --exit-code --tags "https://github.com/${GITHUB_REPOSITORY}.git" \
-            "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+          SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')"
+          if [ -z "$SHA" ]; then
+            SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/${RELEASE_TAG}" | awk '{print $1}')"
+          fi
+          if [ -z "$SHA" ]; then
             echo "::error::tag '${RELEASE_TAG}' does not exist on ${GITHUB_REPOSITORY}"
             exit 1
           fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Checkout minio-cpp
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         path: minio-cpp
-        # Manual dispatch: build the tag the artifacts will be attached to.
-        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+        # Manual dispatch: build the commit the validated tag points to.
+        ref: ${{ github.event_name == 'workflow_dispatch' && steps.validate.outputs.sha || github.sha }}
         persist-credentials: false
 
     - name: Checkout vcpkg
@@ -138,9 +146,11 @@ jobs:
 
     - name: Package bundle
       shell: bash
+      env:
+        RELEASE_ARCHIVE: ${{ steps.tag.outputs.archive }}
       run: |
         set -euo pipefail
-        ARCHIVE="${{ steps.tag.outputs.archive }}"
+        ARCHIVE="$RELEASE_ARCHIVE"
         mv "minio-cpp/build/vcpkg_installed/${{ matrix.triplet }}" "$ARCHIVE"
         if [ "$RUNNER_OS" = "Windows" ]; then
           tar -a -cf "$ARCHIVE.zip" "$ARCHIVE"
@@ -193,9 +203,10 @@ jobs:
     - name: Create or update GitHub release with assets
       env:
         GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ steps.tag.outputs.tag }}
       run: |
         set -euo pipefail
-        TAG="${{ steps.tag.outputs.tag }}"
+        TAG="$RELEASE_TAG"
         if gh release view "$TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
           gh release upload "$TAG" artifacts/* -R "$GITHUB_REPOSITORY" --clobber
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,17 +204,15 @@ jobs:
         RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
         RESOLVED_SHA: ${{ needs.resolve.outputs.sha }}
       run: |
-        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+        SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+          "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')"
+        if [ -z "$SHA" ]; then
           SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
-            "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')"
-          if [ -z "$SHA" ]; then
-            SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
-              "refs/tags/${RELEASE_TAG}" | awk '{print $1}')"
-          fi
-          if [ -z "$SHA" ] || [ "$SHA" != "$RESOLVED_SHA" ]; then
-            echo "::error::tag '${RELEASE_TAG}' moved since the build started"
-            exit 1
-          fi
+            "refs/tags/${RELEASE_TAG}" | awk '{print $1}')"
+        fi
+        if [ -z "$SHA" ] || [ "$SHA" != "$RESOLVED_SHA" ]; then
+          echo "::error::tag '${RELEASE_TAG}' moved since the build started"
+          exit 1
         fi
 
     - name: Create or update GitHub release with assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@
 
 name: Release
 
+concurrency:
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
 on:
   push:
     tags:
@@ -36,13 +40,36 @@ jobs:
             os: macos-15-intel
             triplet: x64-osx
           - name: macos-arm64
-            os: macos-latest
+            os: macos-15
             triplet: arm64-osx
           - name: windows-amd64
             os: windows-latest
             triplet: x64-windows-static
 
     steps:
+    # Manual dispatch: the tag must exist and be a version tag; the build and
+    # the release job (contents: write) depend on it.
+    - name: Validate release tag
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ inputs.tag }}
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          case "$RELEASE_TAG" in
+            v[0-9]*)
+              ;;
+            *)
+              echo "::error::input tag must be an existing version tag, e.g. v0.4.0"
+              exit 1
+              ;;
+          esac
+          if ! git ls-remote --exit-code --tags "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "::error::tag '${RELEASE_TAG}' does not exist on ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+        fi
+
     - name: Checkout minio-cpp
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
@@ -74,9 +101,11 @@ jobs:
     - name: Resolve release tag and archive name
       id: tag
       shell: bash
+      env:
+        RELEASE_TAG: ${{ inputs.tag }}
       run: |
         if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
         else
           TAG="${GITHUB_REF#refs/tags/}"
         fi
@@ -151,9 +180,11 @@ jobs:
 
     - name: Resolve release tag
       id: tag
+      env:
+        RELEASE_TAG: ${{ inputs.tag }}
       run: |
         if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-          TAG="${{ inputs.tag }}"
+          TAG="$RELEASE_TAG"
         else
           TAG="${GITHUB_REF#refs/tags/}"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,56 @@ permissions:
   contents: read   # write is granted only to the release job below
 
 jobs:
+  # Resolve the release tag once (name + commit) so every build job and the
+  # release job operate on the same commit, even if the tag moves later.
+  resolve:
+    name: Resolve release tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      sha: ${{ steps.tag.outputs.sha }}
+    steps:
+    - name: Resolve release tag and commit
+      id: tag
+      env:
+        RELEASE_TAG: ${{ inputs.tag }}
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          case "$RELEASE_TAG" in
+            v[0-9]*)
+              ;;
+            *)
+              echo "::error::input tag must be an existing version tag, e.g. v0.4.0"
+              exit 1
+              ;;
+          esac
+          case "$RELEASE_TAG" in
+            */*)
+              echo "::error::tag '${RELEASE_TAG}' must not contain '/'"
+              exit 1
+              ;;
+          esac
+          SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')"
+          if [ -z "$SHA" ]; then
+            SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/${RELEASE_TAG}" | awk '{print $1}')"
+          fi
+          if [ -z "$SHA" ]; then
+            echo "::error::tag '${RELEASE_TAG}' does not exist on ${GITHUB_REPOSITORY}"
+            exit 1
+          fi
+          TAG="$RELEASE_TAG"
+        else
+          TAG="${GITHUB_REF#refs/tags/}"
+          SHA="$GITHUB_SHA"
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.name }}
+    needs: resolve
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -47,43 +95,11 @@ jobs:
             triplet: x64-windows-static
 
     steps:
-    # Manual dispatch: the tag must exist and be a version tag; the build and
-    # the release job (contents: write) depend on it. Resolve it to its peeled
-    # commit so the checkout below builds that exact commit.
-    - name: Validate release tag
-      id: validate
-      shell: bash
-      env:
-        RELEASE_TAG: ${{ inputs.tag }}
-      run: |
-        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-          case "$RELEASE_TAG" in
-            v[0-9]*)
-              ;;
-            *)
-              echo "::error::input tag must be an existing version tag, e.g. v0.4.0"
-              exit 1
-              ;;
-          esac
-          SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
-            "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')"
-          if [ -z "$SHA" ]; then
-            SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
-              "refs/tags/${RELEASE_TAG}" | awk '{print $1}')"
-          fi
-          if [ -z "$SHA" ]; then
-            echo "::error::tag '${RELEASE_TAG}' does not exist on ${GITHUB_REPOSITORY}"
-            exit 1
-          fi
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Checkout minio-cpp
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         path: minio-cpp
-        # Manual dispatch: build the commit the validated tag points to.
-        ref: ${{ github.event_name == 'workflow_dispatch' && steps.validate.outputs.sha || github.sha }}
+        ref: ${{ needs.resolve.outputs.sha }}
         persist-credentials: false
 
     - name: Checkout vcpkg
@@ -106,19 +122,13 @@ jobs:
           ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
         fi
 
-    - name: Resolve release tag and archive name
+    - name: Resolve archive name
       id: tag
       shell: bash
       env:
-        RELEASE_TAG: ${{ inputs.tag }}
+        RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
       run: |
-        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-          TAG="$RELEASE_TAG"
-        else
-          TAG="${GITHUB_REF#refs/tags/}"
-        fi
-        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-        echo "archive=minio-cpp-${TAG#v}-${{ matrix.name }}" >> "$GITHUB_OUTPUT"
+        echo "archive=minio-cpp-${RELEASE_TAG#v}-${{ matrix.name }}" >> "$GITHUB_OUTPUT"
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
@@ -176,7 +186,7 @@ jobs:
 
   release:
     name: Publish release assets
-    needs: build
+    needs: [build, resolve]
     if: needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -188,22 +198,29 @@ jobs:
         path: artifacts
         merge-multiple: true
 
-    - name: Resolve release tag
-      id: tag
+    # Abort the release if the tag was moved while the build was running.
+    - name: Verify tag still points to the resolved commit
       env:
-        RELEASE_TAG: ${{ inputs.tag }}
+        RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
+        RESOLVED_SHA: ${{ needs.resolve.outputs.sha }}
       run: |
         if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-          TAG="$RELEASE_TAG"
-        else
-          TAG="${GITHUB_REF#refs/tags/}"
+          SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/${RELEASE_TAG}^{}" | awk '{print $1}')"
+          if [ -z "$SHA" ]; then
+            SHA="$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/${RELEASE_TAG}" | awk '{print $1}')"
+          fi
+          if [ -z "$SHA" ] || [ "$SHA" != "$RESOLVED_SHA" ]; then
+            echo "::error::tag '${RELEASE_TAG}' moved since the build started"
+            exit 1
+          fi
         fi
-        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
     - name: Create or update GitHub release with assets
       env:
         GH_TOKEN: ${{ github.token }}
-        RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        RELEASE_TAG: ${{ needs.resolve.outputs.tag }}
       run: |
         set -euo pipefail
         TAG="$RELEASE_TAG"
@@ -211,5 +228,5 @@ jobs:
           gh release upload "$TAG" artifacts/* -R "$GITHUB_REPOSITORY" --clobber
         else
           gh release create "$TAG" artifacts/* -R "$GITHUB_REPOSITORY" \
-            --title "minio-cpp $TAG" --generate-notes
+            --title "minio-cpp $TAG" --generate-notes --verify-tag
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,188 @@
+# Builds self-contained prebuilt SDK bundles (headers + static libraries +
+# CMake/pkg-config metadata) for the platforms below and attaches them to a
+# GitHub Release. Consumers download a bundle and use it with
+# `-DCMAKE_PREFIX_PATH=<bundle>` — no vcpkg and no network required.
+#
+# This addresses https://github.com/minio/minio-cpp/issues/212 (prebuilt
+# arm64 releases).
+#
+# Trigger: push a tag matching v* (e.g. `git tag v0.4.0 && git push --tags`),
+# or run manually via Actions -> "Release" -> "Run workflow", providing the
+# tag the artifacts should be attached to.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Tag to attach the prebuilt artifacts to, e.g. v0.4.0. The tag must
+          already exist on the repository (push it first).
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-amd64
+            os: ubuntu-24.04
+            triplet: x64-linux
+            package: tar.gz
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            triplet: arm64-linux
+            package: tar.gz
+          - name: macos-amd64
+            os: macos-15-intel
+            triplet: x64-osx
+            package: tar.gz
+          - name: macos-arm64
+            os: macos-latest
+            triplet: arm64-osx
+            package: tar.gz
+          - name: windows-amd64
+            os: windows-latest
+            triplet: x64-windows
+            package: zip
+
+    steps:
+    - name: Checkout minio-cpp
+      uses: actions/checkout@v4
+      with:
+        path: minio-cpp
+
+    - name: Checkout vcpkg
+      uses: actions/checkout@v4
+      with:
+        repository: microsoft/vcpkg
+        ref: "2026.07.29"
+        path: vcpkg
+
+    # arm64 Linux has no prebuilt vcpkg CMake, so vcpkg falls back to the
+    # system cmake; the apt version (3.28) is too old for vcpkg's SPDX
+    # generation. Provide a recent cmake on PATH (same as ci.yml).
+    - name: Install recent CMake and Ninja
+      uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+
+    - name: Bootstrap vcpkg
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
+        else
+          ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+        fi
+
+    - name: Resolve release tag and archive name
+      id: tag
+      shell: bash
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          TAG="${{ inputs.tag }}"
+        else
+          TAG="${GITHUB_REF#refs/tags/}"
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "archive=minio-cpp-${TAG#v}-${{ matrix.name }}" >> "$GITHUB_OUTPUT"
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install pkg-config
+
+    - name: Configure and build
+      shell: bash
+      run: |
+        cd minio-cpp
+        ../vcpkg/vcpkg install
+        cmake . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
+        cmake --build build --config Release -j 4
+
+    # vcpkg's manifest mode installs dependencies into
+    # <build>/vcpkg_installed/<triplet>. Installing miniocpp into that same
+    # prefix produces one flat, relocatable SDK bundle: all headers, all
+    # static libraries (miniocpp plus its dependencies) and all CMake configs
+    # live under a single directory that consumers can point
+    # CMAKE_PREFIX_PATH at.
+    - name: Install into SDK bundle
+      shell: bash
+      run: |
+        cd minio-cpp
+        cmake --install build --config Release \
+          --prefix "build/vcpkg_installed/${{ matrix.triplet }}"
+
+    - name: Package bundle
+      shell: bash
+      run: |
+        set -euo pipefail
+        ARCHIVE="${{ steps.tag.outputs.archive }}"
+        mv "minio-cpp/build/vcpkg_installed/${{ matrix.triplet }}" "$ARCHIVE"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          tar -a -cf "$ARCHIVE.zip" "$ARCHIVE"
+        else
+          tar -czf "$ARCHIVE.tar.gz" "$ARCHIVE"
+        fi
+
+    - name: Upload bundle (tar.gz)
+      if: matrix.package == 'tar.gz'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.tag.outputs.archive }}.tar.gz
+        path: ${{ steps.tag.outputs.archive }}.tar.gz
+        if-no-files-found: error
+
+    - name: Upload bundle (zip)
+      if: matrix.package == 'zip'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.tag.outputs.archive }}.zip
+        path: ${{ steps.tag.outputs.archive }}.zip
+        if-no-files-found: error
+
+  release:
+    name: Publish release assets
+    needs: build
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all bundles
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+        merge-multiple: true
+
+    - name: Resolve release tag
+      id: tag
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+          TAG="${{ inputs.tag }}"
+        else
+          TAG="${GITHUB_REF#refs/tags/}"
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+    - name: Create or update GitHub release with assets
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        TAG="${{ steps.tag.outputs.tag }}"
+        if gh release view "$TAG" -R "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          gh release upload "$TAG" artifacts/* -R "$GITHUB_REPOSITORY" --clobber
+        else
+          gh release create "$TAG" artifacts/* -R "$GITHUB_REPOSITORY" \
+            --title "minio-cpp $TAG" --generate-notes
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,6 @@
-# Builds self-contained prebuilt SDK bundles (headers + static libraries +
-# CMake/pkg-config metadata) for the platforms below and attaches them to a
-# GitHub Release. Consumers download a bundle and use it with
-# `-DCMAKE_PREFIX_PATH=<bundle>` — no vcpkg and no network required.
-#
-# This addresses https://github.com/minio/minio-cpp/issues/212 (prebuilt
-# arm64 releases).
-#
-# Trigger: push a tag matching v* (e.g. `git tag v0.4.0 && git push --tags`),
-# or run manually via Actions -> "Release" -> "Run workflow", providing the
-# tag the artifacts should be attached to.
+# Builds prebuilt SDK bundles (headers + static libs + CMake metadata) for
+# common platforms incl. arm64 and attaches them to a GitHub Release.
+# Trigger: push a v* tag, or run manually from the Actions tab.
 
 name: Release
 
@@ -19,14 +11,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: >-
-          Tag to attach the prebuilt artifacts to, e.g. v0.4.0. The tag must
-          already exist on the repository (push it first).
+        description: Tag to attach artifacts to, e.g. v0.4.0 (must exist)
         required: true
         type: string
 
 permissions:
-  contents: write
+  contents: read   # write is granted only to the release job below
 
 jobs:
   build:
@@ -39,40 +29,36 @@ jobs:
           - name: linux-amd64
             os: ubuntu-24.04
             triplet: x64-linux
-            package: tar.gz
           - name: linux-arm64
             os: ubuntu-24.04-arm
             triplet: arm64-linux
-            package: tar.gz
           - name: macos-amd64
             os: macos-15-intel
             triplet: x64-osx
-            package: tar.gz
           - name: macos-arm64
             os: macos-latest
             triplet: arm64-osx
-            package: tar.gz
           - name: windows-amd64
             os: windows-latest
-            triplet: x64-windows
-            package: zip
+            triplet: x64-windows-static
 
     steps:
     - name: Checkout minio-cpp
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         path: minio-cpp
+        # Manual dispatch: build the tag the artifacts will be attached to.
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+        persist-credentials: false
 
     - name: Checkout vcpkg
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         repository: microsoft/vcpkg
-        ref: "2026.07.29"
+        ref: 9e593bb18ea69cc5095e012465dcd675a822ed0d # 2026.07.29
         path: vcpkg
+        persist-credentials: false
 
-    # arm64 Linux has no prebuilt vcpkg CMake, so vcpkg falls back to the
-    # system cmake; the apt version (3.28) is too old for vcpkg's SPDX
-    # generation. Provide a recent cmake on PATH (same as ci.yml).
     - name: Install recent CMake and Ninja
       uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
 
@@ -105,18 +91,15 @@ jobs:
       shell: bash
       run: |
         cd minio-cpp
-        ../vcpkg/vcpkg install
+        ../vcpkg/vcpkg install --triplet "${{ matrix.triplet }}"
         cmake . -B build \
           -DCMAKE_BUILD_TYPE=Release \
+          -DVCPKG_TARGET_TRIPLET="${{ matrix.triplet }}" \
           -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake
         cmake --build build --config Release -j 4
 
-    # vcpkg's manifest mode installs dependencies into
-    # <build>/vcpkg_installed/<triplet>. Installing miniocpp into that same
-    # prefix produces one flat, relocatable SDK bundle: all headers, all
-    # static libraries (miniocpp plus its dependencies) and all CMake configs
-    # live under a single directory that consumers can point
-    # CMAKE_PREFIX_PATH at.
+    # Install miniocpp into vcpkg's dep prefix so the bundle is one flat,
+    # relocatable directory: headers + all static libs + CMake configs.
     - name: Install into SDK bundle
       shell: bash
       run: |
@@ -137,16 +120,16 @@ jobs:
         fi
 
     - name: Upload bundle (tar.gz)
-      if: matrix.package == 'tar.gz'
-      uses: actions/upload-artifact@v4
+      if: runner.os != 'Windows'
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ steps.tag.outputs.archive }}.tar.gz
         path: ${{ steps.tag.outputs.archive }}.tar.gz
         if-no-files-found: error
 
     - name: Upload bundle (zip)
-      if: matrix.package == 'zip'
-      uses: actions/upload-artifact@v4
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ steps.tag.outputs.archive }}.zip
         path: ${{ steps.tag.outputs.archive }}.zip
@@ -157,9 +140,11 @@ jobs:
     needs: build
     if: needs.build.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # only this job may create/update the release
     steps:
     - name: Download all bundles
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         path: artifacts
         merge-multiple: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ set(MINIO_CPP_HEADERS
   include/miniocpp/providers.h
   include/miniocpp/request.h
   include/miniocpp/response.h
+  include/miniocpp/result.h
   include/miniocpp/select.h
   include/miniocpp/signer.h
   include/miniocpp/sse.h
@@ -312,6 +313,11 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/miniocpp-config.cmake"
 
 install(FILES
         ${MINIO_CPP_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/miniocpp")
+
+# Vendored third-party headers referenced by public miniocpp headers
+# (e.g. tl::expected for C++17 builds) must ship with the install tree.
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/tl"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 configure_file(miniocpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/miniocpp.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/miniocpp.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,8 +314,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/miniocpp-config.cmake"
 install(FILES
         ${MINIO_CPP_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/miniocpp")
 
-# Vendored third-party headers referenced by public miniocpp headers
-# (e.g. tl::expected for C++17 builds) must ship with the install tree.
+# Vendored headers referenced by public miniocpp headers must ship too.
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/tl"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,39 @@ Typically `minio-cpp` will be part of dependencies specified in `vcpkg.json` fil
 }
 ```
 
+## Prebuilt release bundles
+
+Don't want to (or can't) use `vcpkg` — for example because of network
+restrictions? Every [GitHub release](https://github.com/minio/minio-cpp/releases)
+ships self-contained, prebuilt SDK bundles for the most common platforms,
+including arm64:
+
+| Platform                    | Bundle                                              |
+| --------------------------- | --------------------------------------------------- |
+| Linux x86_64                | `minio-cpp-<version>-linux-amd64.tar.gz`            |
+| Linux arm64 (Graviton, RPi) | `minio-cpp-<version>-linux-arm64.tar.gz`            |
+| macOS x86_64                | `minio-cpp-<version>-macos-amd64.tar.gz`            |
+| macOS arm64 (Apple silicon) | `minio-cpp-<version>-macos-arm64.tar.gz`            |
+| Windows x86_64              | `minio-cpp-<version>-windows-amd64.zip`             |
+
+Each bundle is a single relocatable prefix containing everything needed to
+build and link against the SDK: the `miniocpp` headers, static libraries
+(`miniocpp` and all of its dependencies), CMake package configs and the
+`miniocpp.pc` file. Download a bundle, extract it, and point CMake at it:
+
+```bash
+$ curl -LO https://github.com/minio/minio-cpp/releases/download/<version>/minio-cpp-<version>-linux-arm64.tar.gz
+$ tar -xzf minio-cpp-<version>-linux-arm64.tar.gz
+$ cmake -S . -B build -DCMAKE_PREFIX_PATH="$PWD/minio-cpp-<version>-linux-arm64"
+```
+
+No `vcpkg`, no network and no extra dependency installation is required —
+`find_package(miniocpp REQUIRED)` in your `CMakeLists.txt` resolves the
+bundle exactly like the section below. The bundles are built automatically
+from every pushed `v*` tag (and can also be built on demand from the
+"Actions" tab); the release workflow lives in
+[`.github/workflows/release.yml`](.github/workflows/release.yml).
+
 ## Using `minio-cpp` with cmake
 
 MinIO C++ cliend SDK can be consumed as a dependency in CMakeLists.txt, the following can be used as an example:

--- a/miniocpp.pc.in
+++ b/miniocpp.pc.in
@@ -1,5 +1,7 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
+# pcfiledir-relative prefix so the file stays valid after relocation
+# (e.g. inside a prebuilt SDK bundle extracted anywhere).
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 

--- a/miniocpp.pc.in
+++ b/miniocpp.pc.in
@@ -1,5 +1,3 @@
-# pcfiledir-relative prefix so the file stays valid after relocation
-# (e.g. inside a prebuilt SDK bundle extracted anywhere).
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@


### PR DESCRIPTION
Fixes #212

## What

Adds a GitHub Actions **Release** workflow (`.github/workflows/release.yml`) that builds self-contained, prebuilt SDK bundles and attaches them to a GitHub Release:

- Triggered by every `v*` tag push, or on demand from the Actions tab (specify the target tag).
- Matrix: `linux-amd64`, **`linux-arm64`**, `macos-amd64`, **`macos-arm64`**, `windows-amd64` (GA hosted runners; arm64 uses `ubuntu-24.04-arm` / `macos-latest`).
- Each bundle is one flat, relocatable prefix: miniocpp headers, all static libraries (miniocpp **and its dependencies**), CMake package configs and `miniocpp.pc`, produced by `cmake --install` into vcpkg's `vcpkg_installed/<triplet>` tree.
- A `release` job creates (or updates, with `--clobber`) the release and uploads all bundles.

Users without vcpkg or a reliable network (the reporter of #212) can then simply:

```bash
curl -LO https://github.com/minio/minio-cpp/releases/download/v0.4.0/minio-cpp-v0.4.0-linux-arm64.tar.gz
tar -xzf minio-cpp-v0.4.0-linux-arm64.tar.gz
cmake -S . -B build -DCMAKE_PREFIX_PATH="$PWD/minio-cpp-0.4.0-linux-arm64"
```

No vcpkg, no network, no extra dependency install needed.

## Also fixed: `cmake --install` produced an unusable tree

- `include/miniocpp/result.h` is included by 4 public headers but was missing from `MINIO_CPP_HEADERS`, so it was never installed.
- The vendored `include/tl` (tl::expected, used by `error.h`/`result.h` for C++17) was never installed.

Both are required for any consumer to compile against an installed SDK; validated end-to-end locally with a fresh CMake consumer project (configure → build → run against the bundle with only `CMAKE_PREFIX_PATH`, no vcpkg toolchain).

## Validation

- `actionlint` clean on the new workflow (also on existing workflows).
- Bundle consumption validated locally: `find_package(miniocpp)` resolves OpenSSL, CURL/curlpp, inih, nlohmann_json, pugixml, ZLIB entirely from the bundle prefix.
- Build steps mirror `ci.yml`, which already exercises both `ubuntu-24.04` and `ubuntu-24.04-arm` on every push.

## Note

Windows arm64 and RDMA-enabled bundles are intentionally out of scope for now (no GA vcpkg/runner combination for the former; the RDMA build is covered by `ci-rdma.yml`); the matrix makes both easy to add later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added downloadable prebuilt SDK bundles for Linux, macOS, and Windows on amd64 and arm64.
  * Releases can be created automatically from version tags or manually.

* **Documentation**
  * Added instructions for downloading, extracting, and configuring prebuilt bundles.
  * Documented supported platforms, archive contents, and release options.

* **Improvements**
  * SDK installations now include all required public headers and dependencies.
  * Improved package configuration for relocatable SDK installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->