### PR TITLE
feat(rdma): take a failing rail out of rotation, and report rail counts

### DIFF
--- a/include/miniocpp/c_api.h
+++ b/include/miniocpp/c_api.h
@@ -92,6 +92,17 @@ MINIOCPP_API void miniocpp_free_aligned(void* ptr);
 // require an existing miniocpp_client.
 MINIOCPP_API int miniocpp_rdma_available(void);
 
+// RDMA rails this host can carry traffic on, and how many are usable right
+// now. A healthy count below the total means a rail failed a transfer or lost
+// its port and transfers are going out on what is left; both are 0 when RDMA
+// is unavailable.
+//
+// Transfers spread across rails on their own -- a buffer is registered on all
+// of them and each token names one, chosen round-robin -- so these are for
+// reporting what the host has, not for driving it.
+MINIOCPP_API int miniocpp_rdma_nic_count(void);
+MINIOCPP_API int miniocpp_rdma_healthy_nic_count(void);
+
 // Thread-local last-error message from the most recent failing call on the
 // calling thread. Returns NULL when no error has been recorded. The returned
 // pointer is owned by the library and stable until the next failing call on

--- a/include/miniocpp/rdma.h
+++ b/include/miniocpp/rdma.h
@@ -358,6 +358,14 @@ inline static ssize_t rdmaPutWithRetry(minio::rdma::Client* rdmaclient,
     if (ret > 0 || ret == kRDMANotSupported) {
       return ret;
     }
+    // The transfer failed. Charge it to the rail this token named so the next
+    // request skips that rail rather than round-robinning back onto it. A 501
+    // returns above: the server declining RDMA says nothing about the rail.
+    //
+    // A server-side fault marks every rail in turn, which is safe -- libs3rdma
+    // clears all marks once no rail is left usable, so a fault that was never
+    // the fabric's heals itself.
+    rdmaclient->ReportTokenFailure(token.c_str());
   }
   return ret;
 }
@@ -376,6 +384,8 @@ inline static ssize_t rdmaGetWithRetry(minio::rdma::Client* rdmaclient,
     if (ret > 0 || ret == kRDMANotSupported) {
       return ret;
     }
+    // See rdmaPutWithRetry: take the failing rail out of rotation.
+    rdmaclient->ReportTokenFailure(token.c_str());
   }
   return ret;
 }

--- a/include/miniocpp/rdma_client.h
+++ b/include/miniocpp/rdma_client.h
@@ -136,6 +136,29 @@ class Client {
     return Token{raw};
   }
 
+  /// Rails this client can mint tokens on: every device with an ACTIVE port,
+  /// or the ones named in $S3RDMA_DEVICE.
+  int NicCount() const {
+    return handle_ == nullptr ? 0 : s3rdma_client_nic_count(handle_);
+  }
+
+  /// Rails currently usable. Below NicCount() means a rail failed a transfer
+  /// or lost its port and the client is serving on what is left.
+  int HealthyNicCount() const {
+    return handle_ == nullptr ? 0 : s3rdma_client_healthy_nic_count(handle_);
+  }
+
+  /// Tell the library the transfer for `token` failed, so the rail that token
+  /// named is skipped until it recovers.
+  ///
+  /// Without this a dead rail stays in rotation: the retry re-mints and
+  /// happens to land elsewhere, but the next request round-robins straight
+  /// back onto the dead rail, so every request keeps paying a failed attempt.
+  bool ReportTokenFailure(const char* token) {
+    return handle_ != nullptr && token != nullptr &&
+           s3rdma_client_report_token_failure(handle_, token) == 0;
+  }
+
   static MemoryType GetMemoryType(const void* ptr) {
     return static_cast<MemoryType>(s3rdma_client_memory_type(ptr));
   }

--- a/src/c_api.cc
+++ b/src/c_api.cc
@@ -204,6 +204,22 @@ int miniocpp_rdma_available(void) {
   }
 }
 
+int miniocpp_rdma_nic_count(void) {
+  try {
+    return minio::rdma::Shared().NicCount();
+  } catch (...) {
+    return 0;
+  }
+}
+
+int miniocpp_rdma_healthy_nic_count(void) {
+  try {
+    return minio::rdma::Shared().HealthyNicCount();
+  } catch (...) {
+    return 0;
+  }
+}
+
 const char* miniocpp_last_error(void) {
   return g_last_error.empty() ? nullptr : g_last_error.c_str();
 }


### PR DESCRIPTION
Follow-up to #250. libs3rdma does the multi-rail work — every device with an ACTIVE port is opened, a pinned buffer is registered on **all** of them, and each token names one rail chosen round-robin. What the SDK owes it is telling it when a rail has failed.

## Without that, a dead rail never leaves rotation

The retry re-mints and happens to land on the other rail, so one request recovers. But the **next** request round-robins straight back onto the dead rail. Every request keeps paying a failed attempt against a NIC already known bad, forever.

`rdmaPutWithRetry` and `rdmaGetWithRetry` now report the failure against the rail the token named, which takes it out of rotation.

Two deliberate choices:

- **A 501 returns before that point.** The server declining RDMA says nothing about the rail, and marking one for it would sideline healthy hardware over server policy.
- **A server-side fault marks every rail in turn, and that is safe.** libs3rdma clears all marks once no rail is left usable, so a fault that was never the fabric's heals itself rather than stranding the client on HTTP.

## Rail counts

`Client::NicCount()` / `HealthyNicCount()`, and `miniocpp_rdma_nic_count()` / `miniocpp_rdma_healthy_nic_count()` on the C API — so a caller reaching this library over cgo (minio-go, and warp behind it) can see that a host has two rails and is serving on one. A healthy count below the total is otherwise invisible.

## Verification

On a dual-rail ConnectX host, through the C API:

```
rdma_available=1 rails=2 healthy=2
```

Compiles with `-Wall -Wextra`, `check-style.sh` clean.

## Parity note

minio/minio-rs#235 makes the same change on the Rust side, for the same reason. Both SDKs now report failing rails rather than silently retrying into them.