### PR TITLE
perf(rdma): keep parts in flight on a streaming upload

### DIFF
--- a/src/c_api.cc
+++ b/src/c_api.cc
@@ -58,6 +58,28 @@ class ReadCbStreamBuf : public std::streambuf {
   char buf_[64 * 1024];
 };
 
+// Parts kept in flight for a streaming upload.
+//
+// The default is 1, which uploads parts strictly one at a time: the next part
+// is not read until the previous one has been acknowledged, so the link sits
+// idle for a whole round trip per part. On an RDMA stream that measured
+// 167.7 MiB/s per caller against 318.6 at four-deep.
+//
+// It is not free. The parallel path allocates one part buffer per in-flight
+// part and registers each for RDMA, so the pinned memory is
+// max_inflight_parts * part_size -- 64 MiB at this default. A caller running
+// many concurrent uploads multiplies that, which is why the default stays
+// modest and tuning is left to the environment rather than raised for
+// everyone.
+inline unsigned int StreamInflightParts() {
+  if (const char* env = std::getenv("MINIOCPP_STREAM_INFLIGHT_PARTS")) {
+    char* end = nullptr;
+    const unsigned long v = std::strtoul(env, &end, 10);
+    if (end != env && v >= 1 && v <= 100) return static_cast<unsigned int>(v);
+  }
+  return 4;
+}
+
 struct ClientHolder {
   minio::s3::BaseUrl base_url;
   std::unique_ptr<minio::creds::StaticProvider> provider;
@@ -127,6 +149,7 @@ ssize_t miniocpp_put_object(miniocpp_client* c, const char* bucket,
     args.stream = sis.get();
     args.object_size = static_cast<long>(size);
     args.part_size = 16 * 1024 * 1024L;
+    args.max_inflight_parts = StreamInflightParts();
   }
 
   auto resp = holder->client->PutObject(args);

--- a/src/c_api.cc
+++ b/src/c_api.cc
@@ -60,22 +60,27 @@ class ReadCbStreamBuf : public std::streambuf {
 
 // Parts kept in flight for a streaming upload.
 //
-// The default is 1, which uploads parts strictly one at a time: the next part
-// is not read until the previous one has been acknowledged, so the link sits
-// idle for a whole round trip per part. On an RDMA stream that measured
-// 167.7 MiB/s per caller against 318.6 at four-deep.
+// Left unset, PutObjectArgs keeps one part in flight and uploads strictly one
+// at a time: the next part is not read until the previous one has been
+// acknowledged, so the link sits idle for a whole round trip per part. On an
+// RDMA stream that measured 167.7 MiB/s per caller, against 318.6 at the four
+// this returns.
 //
 // It is not free. The parallel path allocates one part buffer per in-flight
 // part and registers each for RDMA, so the pinned memory is
-// max_inflight_parts * part_size -- 64 MiB at this default. A caller running
-// many concurrent uploads multiplies that, which is why the default stays
-// modest and tuning is left to the environment rather than raised for
-// everyone.
+// max_inflight_parts * part_size -- 64 MiB at four. A caller running many
+// concurrent uploads multiplies that, which is why this stays modest and
+// tuning is left to the environment rather than raised for everyone.
 inline unsigned int StreamInflightParts() {
   if (const char* env = std::getenv("MINIOCPP_STREAM_INFLIGHT_PARTS")) {
     char* end = nullptr;
     const unsigned long v = std::strtoul(env, &end, 10);
-    if (end != env && v >= 1 && v <= 100) return static_cast<unsigned int>(v);
+    // *end == '\0' matters: strtoul stops at the first non-digit and still
+    // reports success, so "99junk" would otherwise select 99 and pin 1.5 GiB
+    // -- the opposite of the modest fallback a typo deserves.
+    if (end != env && *end == '\0' && v >= 1 && v <= 100) {
+      return static_cast<unsigned int>(v);
+    }
   }
   return 4;
 }


### PR DESCRIPTION
A streaming `PutObject` went out **one part at a time**. `max_inflight_parts` defaults to 1 and the C API never set it, so the next part was not read until the previous one had been acknowledged — the link sat idle for a round trip per part.

The parallel path already exists, with a registered buffer pool; it was simply never switched on from the C API.

## Measured

Two-rail mlx5 host streaming 1 GiB over RDMA to a live 4-node cluster, one caller:

| parts in flight | throughput |
|---|---|
| 1 (before) | 166.79 MiB/s |
| **4 (new default)** | **318.84 MiB/s** |
| 8 | 319.58 MiB/s |

Four takes essentially all of the gain, so that is the default rather than something larger.

## The cost, and why the default is modest

It is not free: the parallel path allocates one part buffer per in-flight part and registers each for RDMA, so pinned memory is `max_inflight_parts * part_size` — 64 MiB at this default. A caller running many concurrent uploads multiplies that, which is why the default stays low and `MINIOCPP_STREAM_INFLIGHT_PARTS` (clamped 1..100) is there for deployments that want to trade memory for throughput.

## What this does not fix

It does **not** close the gap to the HTTP streaming path, which reaches 1113 MiB/s per caller on the same generator.

I should be clear about one thing I got wrong while investigating: I expected the remaining cost to be `ReadCbStreamBuf`, whose 64 KiB buffer means ~256 callbacks per 16 MiB part with every byte copied twice. Adding an `xsgetn` override to bypass it changed throughput by **0.9 MiB/s** — the theory was wrong, and I am not landing that change. The remaining gap is still unexplained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for controlling the maximum number of simultaneous parts during streaming uploads.
  * Supports values from 1 to 100, with a default of 4 when unset or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->