### PR TITLE
build: support building on Alpine Linux (musl) without vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,3 +197,47 @@ jobs:
       run: |
         cd minio-cpp/build
         ctest -C ${{ matrix.config.build_type }}
+
+  # Alpine/musl: vcpkg's default setup downloads glibc-linked tools, and
+  # Alpine lacks curlpp / INIReader packages -- exercises the pkg-config +
+  # FetchContent fallback path.
+  build-alpine:
+    name: Alpine_Latest_GCC
+    runs-on: ubuntu-latest
+    container: alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    steps:
+    - name: Install dependencies
+      run: |
+        apk add --no-cache build-base cmake git ninja pkgconf \
+          curl-dev inih-dev nlohmann-json openssl-dev pugixml-dev zlib-dev
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - name: Configure and Build
+      run: |
+        cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DMINIO_CPP_TEST=ON
+        cmake --build build
+    - name: Start MinIO server
+      run: |
+        MINIO_RELEASE=RELEASE.2025-09-07T16-13-09Z
+        wget --quiet https://dl.min.io/server/minio/release/linux-amd64/archive/minio.${MINIO_RELEASE}
+        wget --quiet https://dl.min.io/server/minio/release/linux-amd64/archive/minio.${MINIO_RELEASE}.sha256sum
+        sha256sum -c minio.${MINIO_RELEASE}.sha256sum
+        mv minio.${MINIO_RELEASE} minio
+        chmod +x minio
+        mkdir -p /data
+        MINIO_CI_CD=true ./minio server /data --address 127.0.0.1:9000 &
+        MINIO_PID=$!
+        for i in $(seq 1 30); do
+          if wget -q -O /dev/null http://127.0.0.1:9000/minio/health/live; then
+            exit 0
+          fi
+          kill -0 $MINIO_PID 2>/dev/null || { echo "MinIO server exited"; exit 1; }
+          sleep 1
+        done
+        echo "MinIO server did not become ready"
+        exit 1
+    - name: Run tests
+      run: |
+        SERVER_ENDPOINT=127.0.0.1:9000 ACCESS_KEY=minioadmin SECRET_KEY=minioadmin \
+          ./build/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
 
   # Alpine/musl: vcpkg's default setup downloads glibc-linked tools, and
   # Alpine lacks curlpp / INIReader packages -- exercises the pkg-config +
-  # FetchContent fallback path.
+  # upstream source fallback path.
   build-alpine:
     name: Alpine_Latest_GCC
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ MinIO C++ SDK is an S3-compatible object storage client library. This fork exten
 
 ### Prerequisites
 
-- CMake 3.10+
+- CMake 3.13.4+
 - C++17 compiler
 - vcpkg package manager (set `VCPKG_ROOT` environment variable)
 - `libs3rdma` vendored under `vendor/s3rdma/` (for RDMA support). Build and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13.4)
 if (POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
@@ -92,7 +92,7 @@ endif()
 # Dependencies
 # ------------
 #
-# Resolution (vcpkg -> pkg-config -> FetchContent) lives in
+# Resolution (vcpkg -> pkg-config -> upstream source) lives in
 # cmake/miniocpp-deps.cmake, shared with the installed miniocpp-config.cmake.
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/miniocpp-deps.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.10)
-cmake_policy(SET CMP0091 NEW)
+if (POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
 
 # Minio C++ Project
 # -----------------
@@ -89,22 +91,13 @@ endif()
 
 # Dependencies
 # ------------
+#
+# Resolution (vcpkg -> pkg-config -> FetchContent) lives in
+# cmake/miniocpp-deps.cmake, shared with the installed miniocpp-config.cmake.
 
-find_package(OpenSSL REQUIRED)
-find_package(unofficial-curlpp CONFIG REQUIRED)
-find_package(unofficial-inih CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
-find_package(pugixml CONFIG REQUIRED)
-find_package(ZLIB REQUIRED)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/miniocpp-deps.cmake)
 
-list(APPEND MINIO_CPP_LIBS
-  unofficial::curlpp::curlpp
-  unofficial::inih::inireader
-  nlohmann_json::nlohmann_json
-  pugixml
-  OpenSSL::SSL OpenSSL::Crypto
-  ZLIB::ZLIB
-)
+list(APPEND MINIO_CPP_LIBS ${MINIO_CPP_DEPS_LINK_LIBS})
 
 if (WIN32)
   list(APPEND MINIO_CPP_LIBS wsock32)
@@ -321,12 +314,26 @@ install(TARGETS miniocpp
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
+# Source-built deps must be in an export set for install(EXPORT) to resolve
+# them (curlpp exports itself; miniocpp_inih does not).
+if (MINIO_CPP_DEPS_EXPORT_TARGETS)
+  install(TARGETS ${MINIO_CPP_DEPS_EXPORT_TARGETS}
+          EXPORT miniocpp-targets
+          RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+endif()
+
+# The link interface is not exported; miniocpp-config.cmake re-applies it.
 install(EXPORT miniocpp-targets
         NAMESPACE miniocpp::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp"
-        EXPORT_LINK_INTERFACE_LIBRARIES)
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp")
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/miniocpp-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp")
+
+# The consumer config includes the dependency resolver.
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/miniocpp-deps.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/miniocpp")
 
 install(FILES

--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ $ cd minio-cpp
 $ ./configure.sh -DMINIO_CPP_TEST=ON
 ```
 
+### Building on Alpine Linux (musl)
+
+`vcpkg` can run on Alpine, but its default setup downloads glibc-linked tools
+such as CMake, which do not run on musl (setting `VCPKG_FORCE_SYSTEM_BINARIES`
+forces use of the apk-installed tools instead). Alpine also has no packages
+for `curlpp` or the C++ `INIReader`. The dependency resolver
+(`cmake/miniocpp-deps.cmake`) therefore falls back to `pkg-config` and then
+to fetching those two libraries from source, so a plain system-package build
+works:
+
+```bash
+$ apk add build-base cmake git ninja pkgconf \
+    curl-dev inih-dev nlohmann-json openssl-dev pugixml-dev zlib-dev
+$ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DMINIO_CPP_TEST=ON
+$ cmake --build build
+```
+
 ## Example:: file-uploader.cc
 
 ```c++

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For a complete list of APIs and examples, please take a look at the [MinIO C++ C
 
 ## Build Requirements
 
-* [cmake](https://cmake.org/) 3.10 or higher.
+* [cmake](https://cmake.org/) 3.13.4 or higher.
 * [vcpkg](https://vcpkg.io/en/index.html) package manager.
 * A working C++ compiler that supports at least C++17.
 
@@ -69,7 +69,7 @@ from every pushed `v*` tag (and can also be built on demand from the
 MinIO C++ cliend SDK can be consumed as a dependency in CMakeLists.txt, the following can be used as an example:
 
 ```cmake
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13.4)
 
 project(miniocpp_example LANGUAGES C CXX)
 

--- a/cmake/miniocpp-deps.cmake
+++ b/cmake/miniocpp-deps.cmake
@@ -5,7 +5,7 @@
 # upstream source.  The source branch is for distros where vcpkg is
 # impractical (its default setup downloads glibc-linked tools that do not run
 # on musl) and no curlpp / C++ INIReader packages exist.  It clones at
-# configure time with plain git, so it works on the CMake 3.10 floor (no
+# configure time with plain git, so it works on the CMake 3.13.4 floor (no
 # FetchContent); vcpkg builds never reach it.
 #
 # Defines for the caller:
@@ -43,13 +43,15 @@ else()
       if (NOT _curlpp_clone STREQUAL "0")
         message(FATAL_ERROR "curlpp: git clone failed")
       endif()
-      execute_process(COMMAND git checkout --quiet
-                      ec1b66e699557cd9d608d322c013a1ebda16bd08
-                      WORKING_DIRECTORY "${MINIO_CPP_CURLPP_SRC}"
-                      RESULT_VARIABLE _curlpp_checkout)
-      if (NOT _curlpp_checkout STREQUAL "0")
-        message(FATAL_ERROR "curlpp: git checkout of pinned commit failed")
-      endif()
+    endif()
+    # Also reset a cached checkout to the pinned commit, not just a fresh
+    # clone.
+    execute_process(COMMAND git checkout --quiet
+                    ec1b66e699557cd9d608d322c013a1ebda16bd08
+                    WORKING_DIRECTORY "${MINIO_CPP_CURLPP_SRC}"
+                    RESULT_VARIABLE _curlpp_checkout)
+    if (NOT _curlpp_checkout STREQUAL "0")
+      message(FATAL_ERROR "curlpp: git checkout of pinned commit failed")
     endif()
     set(CURLPP_BUILD_SHARED_LIBS OFF CACHE BOOL "Build curlpp shared library" FORCE)
     add_subdirectory("${MINIO_CPP_CURLPP_SRC}"
@@ -85,13 +87,15 @@ else()
         if (NOT _inih_clone STREQUAL "0")
           message(FATAL_ERROR "inih: git clone failed")
         endif()
-        execute_process(COMMAND git checkout --quiet
-                        5cc5e2c24642513aaa5b19126aad42d0e4e0923e # r58
-                        WORKING_DIRECTORY "${MINIO_CPP_INIH_SRC}"
-                        RESULT_VARIABLE _inih_checkout)
-        if (NOT _inih_checkout STREQUAL "0")
-          message(FATAL_ERROR "inih: git checkout of pinned commit failed")
-        endif()
+      endif()
+      # Also reset a cached checkout to the pinned commit, not just a fresh
+      # clone.
+      execute_process(COMMAND git checkout --quiet
+                      5cc5e2c24642513aaa5b19126aad42d0e4e0923e # r58
+                      WORKING_DIRECTORY "${MINIO_CPP_INIH_SRC}"
+                      RESULT_VARIABLE _inih_checkout)
+      if (NOT _inih_checkout STREQUAL "0")
+        message(FATAL_ERROR "inih: git checkout of pinned commit failed")
       endif()
       add_library(miniocpp_inih STATIC
         "${MINIO_CPP_INIH_SRC}/ini.c"

--- a/cmake/miniocpp-deps.cmake
+++ b/cmake/miniocpp-deps.cmake
@@ -1,0 +1,132 @@
+# miniocpp-deps.cmake -- resolve the third-party dependencies of minio-cpp.
+# Shared with the installed miniocpp-config.cmake.
+#
+# Resolution order per dependency: vcpkg CONFIG package -> pkg-config ->
+# upstream source.  The source branch is for distros where vcpkg is
+# impractical (its default setup downloads glibc-linked tools that do not run
+# on musl) and no curlpp / C++ INIReader packages exist.  It clones at
+# configure time with plain git, so it works on the CMake 3.10 floor (no
+# FetchContent); vcpkg builds never reach it.
+#
+# Defines for the caller:
+#   MINIO_CPP_DEPS_LINK_LIBS      -- link targets, in link order
+#   MINIO_CPP_DEPS_EXPORT_TARGETS -- source-built targets the caller must
+#                                    install into an export set
+
+set(MINIO_CPP_DEPS_EXPORT_TARGETS)
+
+find_package(PkgConfig QUIET)
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(nlohmann_json CONFIG REQUIRED)
+
+# curlpp -- pinned master commit, no patches needed: CURLOPT_CLOSEPOLICY is
+# gone upstream (dropped in curl 8.10) and the build is target-based and
+# self-exporting.  Static target keeps BUILD_SHARED_LIBS=OFF builds working.
+find_package(unofficial-curlpp CONFIG QUIET)
+if (unofficial-curlpp_FOUND)
+  set(MINIO_CPP_CURLPP_TARGET unofficial::curlpp::curlpp)
+else()
+  if (PkgConfig_FOUND)
+    pkg_check_modules(MINIO_CPP_CURLPP QUIET IMPORTED_TARGET curlpp)
+  endif()
+  if (MINIO_CPP_CURLPP_FOUND)
+    set(MINIO_CPP_CURLPP_TARGET PkgConfig::MINIO_CPP_CURLPP)
+  else()
+    message(STATUS "curlpp: no package found, building from source")
+    set(MINIO_CPP_CURLPP_SRC "${CMAKE_CURRENT_BINARY_DIR}/_deps/curlpp-src")
+    if (NOT EXISTS "${MINIO_CPP_CURLPP_SRC}/CMakeLists.txt")
+      execute_process(COMMAND git clone --quiet
+                      https://github.com/jpbarrette/curlpp.git
+                      "${MINIO_CPP_CURLPP_SRC}"
+                      RESULT_VARIABLE _curlpp_clone)
+      if (NOT _curlpp_clone STREQUAL "0")
+        message(FATAL_ERROR "curlpp: git clone failed")
+      endif()
+      execute_process(COMMAND git checkout --quiet
+                      ec1b66e699557cd9d608d322c013a1ebda16bd08
+                      WORKING_DIRECTORY "${MINIO_CPP_CURLPP_SRC}"
+                      RESULT_VARIABLE _curlpp_checkout)
+      if (NOT _curlpp_checkout STREQUAL "0")
+        message(FATAL_ERROR "curlpp: git checkout of pinned commit failed")
+      endif()
+    endif()
+    set(CURLPP_BUILD_SHARED_LIBS OFF CACHE BOOL "Build curlpp shared library" FORCE)
+    add_subdirectory("${MINIO_CPP_CURLPP_SRC}"
+                     "${CMAKE_CURRENT_BINARY_DIR}/_deps/curlpp-build")
+    set(MINIO_CPP_CURLPP_TARGET curlpp_static)
+    set_target_properties(curlpp_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  endif()
+endif()
+
+# inih -- Alpine ships only the C library; build the C++ INIReader from source
+# (inih is meson-only, hence the manual target).  An installed
+# miniocpp::miniocpp_inih (shipped with the miniocpp install) is reused as-is.
+if (TARGET miniocpp::miniocpp_inih)
+  set(MINIO_CPP_INIH_TARGET miniocpp::miniocpp_inih)
+else()
+  find_package(unofficial-inih CONFIG QUIET)
+  if (unofficial-inih_FOUND)
+    set(MINIO_CPP_INIH_TARGET unofficial::inih::inireader)
+  else()
+    if (PkgConfig_FOUND)
+      pkg_check_modules(MINIO_CPP_INIREADER QUIET IMPORTED_TARGET inireader)
+    endif()
+    if (MINIO_CPP_INIREADER_FOUND)
+      set(MINIO_CPP_INIH_TARGET PkgConfig::MINIO_CPP_INIREADER)
+    else()
+      message(STATUS "inih INIReader: no package found, building from source")
+      set(MINIO_CPP_INIH_SRC "${CMAKE_CURRENT_BINARY_DIR}/_deps/inih-src")
+      if (NOT EXISTS "${MINIO_CPP_INIH_SRC}/ini.h")
+        execute_process(COMMAND git clone --quiet
+                        https://github.com/benhoyt/inih.git
+                        "${MINIO_CPP_INIH_SRC}"
+                        RESULT_VARIABLE _inih_clone)
+        if (NOT _inih_clone STREQUAL "0")
+          message(FATAL_ERROR "inih: git clone failed")
+        endif()
+        execute_process(COMMAND git checkout --quiet
+                        5cc5e2c24642513aaa5b19126aad42d0e4e0923e # r58
+                        WORKING_DIRECTORY "${MINIO_CPP_INIH_SRC}"
+                        RESULT_VARIABLE _inih_checkout)
+        if (NOT _inih_checkout STREQUAL "0")
+          message(FATAL_ERROR "inih: git checkout of pinned commit failed")
+        endif()
+      endif()
+      add_library(miniocpp_inih STATIC
+        "${MINIO_CPP_INIH_SRC}/ini.c"
+        "${MINIO_CPP_INIH_SRC}/cpp/INIReader.cpp"
+      )
+      # BUILD_INTERFACE only: the cloned tree lives in the build dir.
+      target_include_directories(miniocpp_inih PUBLIC
+        $<BUILD_INTERFACE:${MINIO_CPP_INIH_SRC}/cpp>)
+      set_target_properties(miniocpp_inih PROPERTIES POSITION_INDEPENDENT_CODE ON)
+      set(MINIO_CPP_INIH_TARGET miniocpp_inih)
+      list(APPEND MINIO_CPP_DEPS_EXPORT_TARGETS miniocpp_inih)
+    endif()
+  endif()
+endif()
+
+find_package(pugixml CONFIG QUIET)
+if (pugixml_FOUND)
+  set(MINIO_CPP_PUGIXML_TARGET pugixml)
+else()
+  if (PkgConfig_FOUND)
+    pkg_check_modules(MINIO_CPP_PUGIXML QUIET IMPORTED_TARGET pugixml)
+  endif()
+  if (NOT MINIO_CPP_PUGIXML_FOUND)
+    message(FATAL_ERROR
+      "pugixml: neither a CMake package (pugixml) nor pkg-config (pugixml.pc) was found")
+  endif()
+  set(MINIO_CPP_PUGIXML_TARGET PkgConfig::MINIO_CPP_PUGIXML)
+endif()
+
+set(MINIO_CPP_DEPS_LINK_LIBS
+  ${MINIO_CPP_CURLPP_TARGET}
+  ${MINIO_CPP_INIH_TARGET}
+  nlohmann_json::nlohmann_json
+  ${MINIO_CPP_PUGIXML_TARGET}
+  OpenSSL::SSL
+  OpenSSL::Crypto
+  ZLIB::ZLIB
+)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ For a complete list of APIs and examples, please take a look at the [MinIO C++ C
 
 ## Build requirements
 * A working C++ development environment supporting C++17 standards.
-* CMake 3.10 or higher.
+* CMake 3.13.4 or higher.
 * [vcpkg](https://vcpkg.io/en/index.html).
 
 ## Install from vcpkg

--- a/miniocpp-config.cmake.in
+++ b/miniocpp-config.cmake.in
@@ -1,10 +1,10 @@
 @PACKAGE_INIT@
 
-find_package(OpenSSL REQUIRED)
-find_package(unofficial-curlpp CONFIG REQUIRED)
-find_package(unofficial-inih CONFIG REQUIRED)
-find_package(nlohmann_json CONFIG REQUIRED)
-find_package(pugixml CONFIG REQUIRED)
-find_package(ZLIB REQUIRED)
-
+# The exported miniocpp::miniocpp_inih target must be visible to the
+# dependency resolver, so it can be reused instead of re-fetched.
 include("${CMAKE_CURRENT_LIST_DIR}/miniocpp-targets.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/miniocpp-deps.cmake")
+
+# The link interface is not exported; re-apply it.
+target_link_libraries(miniocpp::miniocpp INTERFACE ${MINIO_CPP_DEPS_LINK_LIBS})

--- a/miniocpp-config.cmake.in
+++ b/miniocpp-config.cmake.in
@@ -6,5 +6,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/miniocpp-targets.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/miniocpp-deps.cmake")
 
-# The link interface is not exported; re-apply it.
-target_link_libraries(miniocpp::miniocpp INTERFACE ${MINIO_CPP_DEPS_LINK_LIBS})
+# The link interface is not exported; re-apply it.  set_property is used
+# instead of target_link_libraries so the imported target stays compatible
+# with the CMake 3.13.4 minimum.
+set_property(TARGET miniocpp::miniocpp APPEND PROPERTY
+             INTERFACE_LINK_LIBRARIES ${MINIO_CPP_DEPS_LINK_LIBS})


### PR DESCRIPTION
Fixes #213 — the reporter wants to build and run minio-cpp in an Alpine Linux Docker image: "Alpine uses musl libc while vcpkg's prebuilt CMake requires glibc — they are incompatible." On top of that, Alpine ships no packages for curlpp or the C++ INIReader, so those two must be resolved without vcpkg.

## What changes

Dependency resolution moves into `cmake/miniocpp-deps.cmake` (shared by the top-level CMakeLists and the installed `miniocpp-config.cmake`). Each dependency now resolves in order:

1. vcpkg CONFIG package — unchanged for existing vcpkg builds
2. distro package via pkg-config
3. upstream source via FetchContent — for distros with no package:
   - curlpp pinned to a master commit (`ec1b66e`) that needs no patches: the `CURLOPT_CLOSEPOLICY` typedef was removed upstream (the constant was dropped in curl 8.10) and the build publishes target-based include dirs; the static `curlpp_static` target keeps `BUILD_SHARED_LIBS=OFF` builds working
   - inih built as a manual target from source (inih is meson-only upstream; Alpine ships only the C library, not `INIReader.h`)

### Export/interface handling

`install(EXPORT miniocpp-targets)` validates that every target referenced by the link interface is itself in an export set. On the source-built fallback path the dependency targets are real (not imported) targets, so:

- the export no longer bakes in `INTERFACE_LINK_LIBRARIES` (`EXPORT_LINK_INTERFACE_LIBRARIES` dropped);
- the installed `miniocpp-config.cmake` re-applies `MINIO_CPP_DEPS_LINK_LIBS` after including the export, so consumers get the same transitive interface either way;
- fallback-built targets (`miniocpp_inih`) are installed into the export set so generation succeeds; curlpp exports itself through its own install rules.

Also adds an Alpine CI job and README build instructions. No library source is touched; for vcpkg builds the resolved link libraries are the same list as before.

## Validation

- Existing matrix (Ubuntu GCC 17/20, arm64, Windows MSVC, macOS) — vcpkg CONFIG path
- New `Alpine_Latest_GCC` job — builds on musl and runs the full test suite against a MinIO server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for building and testing on Alpine Linux, including musl-based environments.
  - Improved dependency discovery and fallback handling across supported build environments.
  - Improved installed package configuration for more consistent dependency resolution.

- **Documentation**
  - Added Alpine Linux setup instructions, including required packages, CMake, Ninja, dependency configuration, and testing.
  - Updated the minimum supported CMake version to 3.13.4.

- **Tests**
  - Added automated Alpine Linux builds and test runs using a local MinIO server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->