### PR TITLE
rdma: expose ranged GET through the C ABI

### DIFF
--- a/include/miniocpp/c_api.h
+++ b/include/miniocpp/c_api.h
@@ -22,6 +22,7 @@
 #ifdef MINIO_CPP_RDMA
 
 #include <stddef.h>
+#include <stdint.h>
 #include <sys/types.h>  // ssize_t
 
 #ifdef __cplusplus
@@ -81,6 +82,25 @@ MINIOCPP_API ssize_t miniocpp_get_object(miniocpp_client* client,
                                          void* buf, size_t size,
                                          miniocpp_write_cb write_cb,
                                          void* userdata);
+
+// Ranged GET: read `size` bytes starting at `offset` in the object into `buf`.
+// Transport behaviour matches miniocpp_get_object (RDMA into the caller's
+// buffer, HTTP-into-buf on decline); AIStor answers a ranged RDMA transfer with
+// x-amz-rdma-reply: 206.
+//
+// GetObjectArgs already carries an offset and Client::GetObject already turns
+// it into a ranged RDMA GET, but the C ABI had no way to set it, so bindings
+// could only ever fetch whole objects. Two things that needs:
+//
+//   - reading part of a large object without transferring all of it;
+//   - letting several threads cooperate on one buffer, each filling a disjoint
+//     window of it, instead of every thread needing a buffer of its own.
+//
+// Returns bytes transferred, or MINIOCPP_ERR_*. `buf` is required.
+MINIOCPP_API ssize_t miniocpp_get_object_range(miniocpp_client* client,
+                                               const char* bucket,
+                                               const char* object, void* buf,
+                                               size_t size, uint64_t offset);
 
 // Page-aligned host allocator suitable for RDMA registration. Caller must
 // release with miniocpp_free_aligned. Returns NULL on allocation failure.

--- a/src/c_api.cc
+++ b/src/c_api.cc
@@ -15,6 +15,7 @@
 
 #include <unistd.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <istream>
@@ -145,9 +146,14 @@ ssize_t miniocpp_put_object(miniocpp_client* c, const char* bucket,
   return static_cast<ssize_t>(size);
 }
 
-ssize_t miniocpp_get_object(miniocpp_client* c, const char* bucket,
-                            const char* object, void* buf, size_t size,
-                            miniocpp_write_cb write_cb, void* userdata) {
+namespace {
+
+// Body shared by miniocpp_get_object and miniocpp_get_object_range.
+// `offset` < 0 reads the whole object; >= 0 selects a byte range.
+ssize_t GetObjectImpl(miniocpp_client* c, const char* bucket,
+                      const char* object, void* buf, size_t size,
+                      miniocpp_write_cb write_cb, void* userdata,
+                      int64_t offset) {
   if (c == nullptr || bucket == nullptr || object == nullptr) {
     SetLastError("client, bucket, object are required");
     return MINIOCPP_ERR_INVALID_ARG;
@@ -162,6 +168,7 @@ ssize_t miniocpp_get_object(miniocpp_client* c, const char* bucket,
   args.bucket = bucket;
   args.object = object;
   args.region = holder->base_url.region;
+  if (offset >= 0) args.offset = static_cast<size_t>(offset);
 
   ssize_t bytes_seen = 0;
 
@@ -184,6 +191,31 @@ ssize_t miniocpp_get_object(miniocpp_client* c, const char* bucket,
     return MINIOCPP_ERR_GENERIC;
   }
   return buf != nullptr ? static_cast<ssize_t>(size) : bytes_seen;
+}
+
+}  // namespace
+
+ssize_t miniocpp_get_object(miniocpp_client* c, const char* bucket,
+                            const char* object, void* buf, size_t size,
+                            miniocpp_write_cb write_cb, void* userdata) {
+  return GetObjectImpl(c, bucket, object, buf, size, write_cb, userdata, -1);
+}
+
+ssize_t miniocpp_get_object_range(miniocpp_client* c, const char* bucket,
+                                  const char* object, void* buf, size_t size,
+                                  uint64_t offset) {
+  if (buf == nullptr) {
+    SetLastError("buf is required for a ranged get");
+    return MINIOCPP_ERR_INVALID_ARG;
+  }
+  // GetObjectArgs::offset is a size_t and the range header is built from a
+  // signed value; refuse anything that would not survive the round trip.
+  if (offset > static_cast<uint64_t>(INT64_MAX)) {
+    SetLastError("offset out of range");
+    return MINIOCPP_ERR_INVALID_ARG;
+  }
+  return GetObjectImpl(c, bucket, object, buf, size, nullptr, nullptr,
+                       static_cast<int64_t>(offset));
 }
 
 void* miniocpp_alloc_aligned(size_t size) {


### PR DESCRIPTION
## Problem

`GetObjectArgs` already carries an `offset`, and `Client::GetObject` already turns it into a ranged RDMA GET — AIStor answers one with `x-amz-rdma-reply: 206`. But the C ABI has no way to set it, so every binding built on `libminiocpp` (minio-go's `rdma.go`, minio-py, or anything else using the stable C ABI) can only ever fetch whole objects.

## Change

Adds `miniocpp_get_object_range()`. Its body is shared with `miniocpp_get_object()` through a file-static helper so the two paths cannot drift. **Existing symbols are untouched**, so the stable ABI is preserved — this is purely additive.

## Why it matters

Two things that were not previously expressible from C:

- reading part of a large object without transferring all of it;
- letting several threads cooperate on **one** buffer, each filling a disjoint window, instead of every thread needing a whole-object buffer of its own.

The second is the one that motivated this. For GPU-Direct each destination buffer is *registered device memory*, so "one buffer per concurrent stream" is expensive — and throughput needs concurrency: on our rig a single stream reads a 256 MiB object at ~8–10 GB/s while 8 streams reach ~25 GB/s. Without a ranged GET the only way to get those 8 streams is 8 separate registered buffers.

## Testing

Built with `-DMINIO_CPP_ENABLE_RDMA=ON` and exercised against a 2-node AIStor cluster (`RELEASE.2026-08-07T18-34-35Z`, 48 NVMe, EC:4) from an 8× H200 host over RoCE, decomposing a 256 MiB object into 8 × 32 MiB windows of a single CUDA buffer:

| Case | Result |
| --- | --- |
| whole-object GET (existing path, regression check) | 268435456 bytes, `sha256 1351b3aa…` |
| 8 **sequential** ranged GETs reassembled | byte-identical (sha256 compared) |
| 8 **concurrent** ranged GETs reassembled | byte-identical |
| transfers actually carried by RDMA | confirmed via server `minio_api_rdma_read_bytes_total` |
| final window (`offset = size - window`) | reads correctly |
| `buf == NULL` | rejected with `MINIOCPP_ERR_INVALID_ARG` |

Confirming RDMA from the *server's* counters matters here: the buffer path falls back to HTTP silently on decline, so a byte-correct result alone would not prove the ranged RDMA path was the one exercised.

`clang-format --style=Google` clean on both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving a specified byte range from an object.
  * Range requests accept a starting offset and destination buffer, returning the number of bytes transferred or an error.
  * Existing object retrieval behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->