### PR TITLE
modules: rename miniocpp -> minio module

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -64,9 +64,9 @@ jobs:
         echo "CC=gcc-14" >> "$GITHUB_ENV"
         echo "CXX=g++-14" >> "$GITHUB_ENV"
 
-    # clang-tools-18 надає clang-scan-deps - Meson шукає бінарник тієї ж
-    # версії, що й сам компілятор, щоб просканувати modules/miniocpp.cc на
-    # залежності для Ninja dyndep.
+    # clang-tools-18 provides clang-scan-deps - Meson looks for the binary
+    # matching the same version as the compiler itself, to scan
+    # modules/minio.cc for dependencies for Ninja dyndep.
     - name: Install Clang 18 if Ubuntu Clang
       if: matrix.config.name == 'Ubuntu_Latest_Clang_Meson'
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 # target's build - the compiler gets whatever flags it needs for a module
 # interface unit (e.g. /interface for MSVC) based on this declaration, not on
 # the file's extension, so any CMake/MSBuild/Meson (via cmake.subproject())
-# consumer of this target picks up `import miniocpp;` automatically. Requires
+# consumer of this target picks up `import minio;` automatically. Requires
 # C++20 (MINIO_CPP_STD=20); silently skipped otherwise for older setups.
 #
 # CMake's module dependency scanning is only implemented for the Ninja,
@@ -424,7 +424,7 @@ endif()
 # installed package (via find_package(miniocpp) + CMake, as opposed to
 # consuming subprojects/miniocpp source directly, or via pkg-config/vcpkg)
 # is missing the generated module metadata CMake needs to let a downstream
-# CMake consumer `import miniocpp;` - see
+# CMake consumer `import minio;` - see
 # https://cmake.org/cmake/help/latest/command/install.html#exporting-c-modules.
 # Separately, installing module interfaces is not supported at all with
 # the Visual Studio generator (independent of the MINIO_CPP_HAS_CXX_MODULE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ target_include_directories(miniocpp PUBLIC
 )
 target_link_libraries(miniocpp PUBLIC ${MINIO_CPP_LIBS})
 
-# Optional C++20 module interface for the public API (modules/miniocpp.cc).
+# Optional C++20 module interface for the public API (modules/minio.cc).
 # FILE_SET CXX_MODULES (CMake 3.28+) attaches it as a real part of the miniocpp
 # target's build - the compiler gets whatever flags it needs for a module
 # interface unit (e.g. /interface for MSVC) based on this declaration, not on
@@ -250,7 +250,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.28" AND MINIO_CPP_STD STREQUAL "20")
       PUBLIC
         FILE_SET CXX_MODULES
         BASE_DIRS modules
-        FILES modules/miniocpp.cc
+        FILES modules/minio.cc
     )
   endif()
 endif()

--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,7 @@ if build_module
   else
     module_cpp_args = []
   endif
-  miniocpp_module_lib = static_library('miniocpp_module', 'modules/miniocpp.cc',
+  miniocpp_module_lib = static_library('miniocpp_module', 'modules/minio.cc',
     include_directories : miniocpp_include,
     dependencies : all_deps,
     cpp_args : module_cpp_args,

--- a/modules/minio.cc
+++ b/modules/minio.cc
@@ -2,7 +2,7 @@ module;
 
 #include <miniocpp/client.h>
 
-export module miniocpp;
+export module minio;
 
 // Re-exporting the public API through the module requires an EXPLICIT using-
 // declaration per symbol (using ns::Symbol;) - not a using-directive (using


### PR DESCRIPTION
Propose to rename C++20 module "minicpp" to "minio", for exmaple

`
import std;
import minio; // was import miniocpp

using boost::asio::awaitable;

int main() {
  setvbuf(stdout, nullptr, _IONBF, 0);
}
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Renamed the optional C++20 module from `miniocpp` to `minio`.
  * Updated CMake and Meson builds to use the renamed module.
  * Corrected and clarified related CI and build documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->